### PR TITLE
Remove unnecessary additions to path

### DIFF
--- a/AddonManagerTest/app/test_cache.py
+++ b/AddonManagerTest/app/test_cache.py
@@ -27,8 +27,6 @@ from datetime import date
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-sys.path.append("../..")
-
 import addonmanager_cache as cache
 from AddonManagerTest.app.mocks import MockPref, MockExists
 

--- a/AddonManagerTest/app/test_installer.py
+++ b/AddonManagerTest/app/test_installer.py
@@ -31,8 +31,6 @@ import tempfile
 from zipfile import ZipFile
 import sys
 
-sys.path.append("../../")  # So the IDE can find the imports below
-
 from addonmanager_installer import InstallationMethod, AddonInstaller, MacroInstaller
 from addonmanager_git import GitManager, initialize_git
 from addonmanager_metadata import MetadataReader

--- a/AddonManagerTest/app/test_macro.py
+++ b/AddonManagerTest/app/test_macro.py
@@ -28,8 +28,6 @@ from typing import Dict
 import unittest
 from unittest.mock import MagicMock
 
-sys.path.append("../../")  # So the IDE can find the
-
 from addonmanager_macro import Macro
 
 

--- a/AddonManagerTest/app/test_macro_parser.py
+++ b/AddonManagerTest/app/test_macro_parser.py
@@ -28,8 +28,6 @@ import os
 import sys
 import unittest
 
-sys.path.append("../../")  # So the IDE can find the classes to run with
-
 from addonmanager_macro_parser import MacroParser
 from AddonManagerTest.app.mocks import MockConsole, CallCatcher, MockThread
 

--- a/AddonManagerTest/app/test_metadata.py
+++ b/AddonManagerTest/app/test_metadata.py
@@ -28,8 +28,6 @@ import unittest.mock as mock
 
 Mock = mock.MagicMock
 
-sys.path.append("../../")
-
 
 class TestVersion(unittest.TestCase):
     def setUp(self) -> None:

--- a/AddonManagerTest/gui/test_python_deps_gui.py
+++ b/AddonManagerTest/gui/test_python_deps_gui.py
@@ -14,10 +14,6 @@ except ImportError:
         from PySide2 import QtCore, QtWidgets
 
 
-sys.path.append(
-    "../.."
-)  # So that when run standalone, the Addon Manager classes imported below are available
-
 from addonmanager_python_deps_gui import (
     PythonPackageManager,
     call_pip,


### PR DESCRIPTION
With the Addon Manager moved to its own repo, these path modifications are no longer needed.