### PR TITLE
Add basic test stubs for all widget classes

### DIFF
--- a/.github/workflows/qt5-tests.yml
+++ b/.github/workflows/qt5-tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Qt5 Test
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/qt6-tests.yml
+++ b/.github/workflows/qt6-tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Qt6 Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
 
     strategy:

--- a/AddonManagerTest/gui/test_widget_addon_buttons.py
+++ b/AddonManagerTest/gui/test_widget_addon_buttons.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 The FreeCAD project association AISBL              *
+# *                                                                         *
+# *   This file is part of the FreeCAD Addon Manager.                       *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+import unittest
+
+from PySideWrapper import QtWidgets
+
+from Widgets.addonmanager_widget_addon_buttons import WidgetAddonButtons
+
+
+class TestWidgetAddonButtons(unittest.TestCase):
+
+    def test_instantiation(self):
+        window = QtWidgets.QDialog()
+        window.setObjectName("Test Widget Addon Buttons")
+        _buttons = WidgetAddonButtons(window)

--- a/AddonManagerTest/gui/test_widget_filter_selector.py
+++ b/AddonManagerTest/gui/test_widget_filter_selector.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 The FreeCAD project association AISBL              *
+# *                                                                         *
+# *   This file is part of the FreeCAD Addon Manager.                       *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+import unittest
+
+from PySideWrapper import QtWidgets
+
+from Widgets.addonmanager_widget_filter_selector import (
+    WidgetFilterSelector,
+    StatusFilter,
+    ContentFilter,
+)
+
+
+class TestWidgetFilterSelector(unittest.TestCase):
+
+    def setUp(self):
+        self.window = QtWidgets.QDialog()
+        self.window.setObjectName("Test Widget Filter Selector Window")
+        self.wfs = WidgetFilterSelector(self.window)
+
+    def tearDown(self):
+        self.window.close()
+
+    def test_instantiation(self):
+        self.assertIsInstance(self.wfs, WidgetFilterSelector)
+
+    def test_set_status_filter(self):
+        """Explicitly setting the status filter should not emit a signal"""
+        signal_caught = False
+
+        def signal_handler():
+            nonlocal signal_caught
+            signal_caught = True
+
+        self.wfs.filter_changed.connect(signal_handler)
+        self.wfs.set_status_filter(StatusFilter.ANY)
+        self.assertFalse(signal_caught)
+
+    def test_set_content_filter(self):
+        """Explicitly setting the content filter should not emit a signal"""
+        signal_caught = False
+
+        def signal_handler():
+            nonlocal signal_caught
+            signal_caught = True
+
+        self.wfs.filter_changed.connect(signal_handler)
+        self.wfs.set_contents_filter(ContentFilter.ANY)
+        self.assertFalse(signal_caught)

--- a/AddonManagerTest/gui/test_widget_global_buttons.py
+++ b/AddonManagerTest/gui/test_widget_global_buttons.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 The FreeCAD project association AISBL              *
+# *                                                                         *
+# *   This file is part of the FreeCAD Addon Manager.                       *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+import unittest
+
+from PySideWrapper import QtWidgets
+
+from Widgets.addonmanager_widget_global_buttons import WidgetGlobalButtonBar
+
+
+class TestWidgetGlobalButtons(unittest.TestCase):
+
+    def setUp(self):
+        self.window = QtWidgets.QDialog()
+        self.window.setObjectName("Test Widget Button Bar Window")
+        self.wbb = WidgetGlobalButtonBar(self.window)
+
+    def tearDown(self):
+        self.window.close()
+        del self.window
+
+    def test_instantiation(self):
+        self.assertIsInstance(self.wbb, WidgetGlobalButtonBar)
+
+    def test_set_number_of_available_updates_to_zero(self):
+        """The string saying that there are no available updates shouldn't contain the number 0"""
+        self.wbb.set_number_of_available_updates(0)
+        self.assertNotIn("0", self.wbb.update_all_addons.text())
+
+    def test_set_number_of_available_updates_to_nonzero(self):
+        """The string saying that there are available updates should contain the number"""
+        self.wbb.set_number_of_available_updates(42)
+        self.assertIn("42", self.wbb.update_all_addons.text())

--- a/AddonManagerTest/gui/test_widget_package_details_view.py
+++ b/AddonManagerTest/gui/test_widget_package_details_view.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 The FreeCAD project association AISBL              *
+# *                                                                         *
+# *   This file is part of the FreeCAD Addon Manager.                       *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+"""Tests for the PackageDetailsView widget. Many tests are currently just stubs that ensure the
+code paths are executed so that the CI can find any errors in Python or Qt5/Qt6 compatibility.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from PySideWrapper import QtWidgets
+
+from Widgets.addonmanager_widget_package_details_view import (
+    PackageDetailsView,
+    UpdateInformation,
+    WarningFlags,
+)
+
+
+class TestPackageDetailsView(unittest.TestCase):
+
+    def setUp(self):
+        self.window = QtWidgets.QDialog()
+        self.window.setObjectName("Test Widget Package Details View Window")
+        self.pdv = PackageDetailsView(self.window)
+
+    def tearDown(self):
+        self.window.close()
+        del self.window
+
+    def test_instantiation(self):
+        self.assertIsInstance(self.pdv, PackageDetailsView)
+
+    def test_set_location_to_empty(self):
+        """When location is set empty, the location display is hidden"""
+        self.pdv.set_location(None)
+        self.assertTrue(self.pdv.location_label.isHidden())
+
+    def test_set_location_to_nonempty(self):
+        """When location is set to a string, the display is shown"""
+        self.pdv.set_location("test")
+        self.assertFalse(self.pdv.location_label.isHidden())
+        self.assertIn("test", self.pdv.location_label.text())
+
+    def test_set_url_to_empty(self):
+        """When URL is set empty, the URL display is hidden"""
+        self.pdv.set_url(None)
+        self.assertTrue(self.pdv.url_label.isHidden())
+
+    def test_set_url_to_nonempty(self):
+        """When URL is set to a string, the URL display is shown"""
+        self.pdv.set_url("test")
+        self.assertFalse(self.pdv.url_label.isHidden())
+        self.assertIn("test", self.pdv.url_label.text())
+
+    def test_set_installed_minimal(self):
+        """Exercise the set_installed method with the minimum arguments"""
+        self.pdv.set_installed(True)
+
+    def test_set_installed_full(self):
+        """Exercise the set_installed method with all arguments"""
+        self.pdv.set_installed(True, 1234567.89, "version", "branch")
+
+    @patch("Widgets.addonmanager_widget_package_details_view.PackageDetailsView.set_location")
+    def test_set_installed_false(self, mock_set_location):
+        """When the package is not installed, the location label is un-set"""
+        self.pdv.set_installed(False)
+        mock_set_location.assert_called_with(None)
+
+    def test_set_update_available_true(self):
+        """Not exhaustive, just test the basic call with update available=True"""
+        self.pdv.set_update_available(UpdateInformation(update_available=True))
+
+    def test_set_update_available_false(self):
+        """Not exhaustive, just test the basic call with update_available=False"""
+        self.pdv.set_update_available(UpdateInformation(update_available=False))
+
+    def test_set_disabled_true(self):
+        self.pdv.set_disabled(True)
+
+    def test_set_disabled_false(self):
+        self.pdv.set_disabled(True)
+
+    def test_allow_disabling_true(self):
+        self.pdv.allow_disabling(True)
+
+    def test_allow_disabling_false(self):
+        self.pdv.allow_disabling(False)
+
+    def test_allow_running_true(self):
+        self.pdv.allow_running(True)
+
+    def test_allow_running_false(self):
+        self.pdv.allow_running(False)
+
+    def test_set_warning_flags_obsolete(self):
+        self.pdv.set_warning_flags(WarningFlags(obsolete=True))
+
+    def test_set_warning_flags_py2(self):
+        self.pdv.set_warning_flags(WarningFlags(python2=True))
+
+    def test_set_warning_flags_freecad_version(self):
+        self.pdv.set_warning_flags(WarningFlags(required_freecad_version="99.0"))
+
+    def test_set_warning_flags_non_osi_approved(self):
+        self.pdv.set_warning_flags(WarningFlags(non_osi_approved=True))
+
+    def test_set_warning_flags_non_fsf_libre(self):
+        self.pdv.set_warning_flags(WarningFlags(non_fsf_libre=True))
+
+    def test_set_new_disabled_status_true(self):
+        self.pdv.set_new_disabled_status(True)
+
+    def test_set_new_disabled_status_false(self):
+        self.pdv.set_new_disabled_status(False)
+
+    def test_set_new_branch(self):
+        self.pdv.set_new_branch("test")
+
+    def test_set_updated(self):
+        self.pdv.set_updated()

--- a/AddonManagerTest/gui/test_widget_readme_browser.py
+++ b/AddonManagerTest/gui/test_widget_readme_browser.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 The FreeCAD project association AISBL              *
+# *                                                                         *
+# *   This file is part of the FreeCAD Addon Manager.                       *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+
+import unittest
+from unittest.mock import patch
+
+from PySideWrapper import QtWidgets
+
+from Widgets.addonmanager_widget_readme_browser import WidgetReadmeBrowser
+
+
+class TestWidgetReadmeBrowser(unittest.TestCase):
+    def setUp(self):
+        self.window = QtWidgets.QDialog()
+        self.window.setObjectName("Test Widget Readme Browser Window")
+        self.pdv = WidgetReadmeBrowser(self.window)
+
+    def tearDown(self):
+        self.window.close()
+        del self.window
+
+    def test_instantiation(self):
+        self.assertIsInstance(self.pdv, WidgetReadmeBrowser)

--- a/AddonManagerTest/gui/test_widget_search.py
+++ b/AddonManagerTest/gui/test_widget_search.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 The FreeCAD project association AISBL              *
+# *                                                                         *
+# *   This file is part of the FreeCAD Addon Manager.                       *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+import unittest
+
+from PySideWrapper import QtWidgets
+from Widgets.addonmanager_widget_search import WidgetSearch
+
+
+class TestWidgetSearch(unittest.TestCase):
+
+    def setUp(self):
+        self.window = QtWidgets.QDialog()
+        self.window.setObjectName("Test Widget Search")
+        self.ws = WidgetSearch(self.window)
+
+    def tearDown(self):
+        self.window.close()
+        del self.window
+
+    def test_instantiation(self):
+        self.assertIsInstance(self.ws, WidgetSearch)
+
+    def test_set_text_filter_no_filter(self):
+        self.ws.set_text_filter(None)
+
+    def test_set_text_filter_good_filter(self):
+        signal_caught = False
+
+        def signal_handler():
+            nonlocal signal_caught
+            signal_caught = True
+
+        self.ws.search_changed.connect(signal_handler)
+        self.ws.set_text_filter("valid regex")
+        self.assertTrue(signal_caught)
+
+    def test_set_text_filter_invalid_filter(self):
+        signal_caught = False
+
+        def signal_handler():
+            nonlocal signal_caught
+            signal_caught = True
+
+        self.ws.search_changed.connect(signal_handler)
+        self.ws.set_text_filter("([a-z]+")
+        self.assertFalse(signal_caught)

--- a/AddonManagerTest/gui/test_widget_view_control_bar.py
+++ b/AddonManagerTest/gui/test_widget_view_control_bar.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 The FreeCAD project association AISBL              *
+# *                                                                         *
+# *   This file is part of the FreeCAD Addon Manager.                       *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+import unittest
+
+from PySideWrapper import QtCore, QtWidgets
+
+from Widgets.addonmanager_widget_view_control_bar import WidgetViewControlBar
+
+
+class TestWidgetViewControlBar(unittest.TestCase):
+    def setUp(self):
+        self.window = QtWidgets.QDialog()
+        self.window.setObjectName("Test Widget View Control Bar")
+        self.vcb = WidgetViewControlBar(self.window)
+
+    def tearDown(self):
+        self.window.close()
+        del self.window
+
+    def test_instantiation(self):
+        self.assertIsInstance(self.vcb, WidgetViewControlBar)
+
+    def test_set_sort_order(self):
+        self.vcb.set_sort_order(QtCore.Qt.AscendingOrder)
+
+    def test_set_rankings_available_true(self):
+        self.vcb.set_rankings_available(True)
+
+    def test_set_rankings_available_false(self):
+        self.vcb.set_rankings_available(False)

--- a/AddonManagerTest/gui/test_widget_view_selector.py
+++ b/AddonManagerTest/gui/test_widget_view_selector.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 The FreeCAD project association AISBL              *
+# *                                                                         *
+# *   This file is part of the FreeCAD Addon Manager.                       *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+import unittest
+
+from PySideWrapper import QtWidgets
+
+from Widgets.addonmanager_widget_view_selector import WidgetViewSelector, AddonManagerDisplayStyle
+
+
+class TestWidgetViewSelector(unittest.TestCase):
+    def setUp(self):
+        self.window = QtWidgets.QDialog()
+        self.window.setObjectName("Test Widget View Selector")
+        self.wvs = WidgetViewSelector(self.window)
+
+    def tearDown(self):
+        self.window.close()
+        del self.window
+
+    def test_instantiation(self):
+        self.assertIsInstance(self.wvs, WidgetViewSelector)
+
+    def test_set_current_view_compact(self):
+        self.wvs.set_current_view(AddonManagerDisplayStyle.COMPACT)
+
+    def test_set_current_view_expanded(self):
+        self.wvs.set_current_view(AddonManagerDisplayStyle.EXPANDED)
+
+    def test_set_current_view_composite(self):
+        self.wvs.set_current_view(AddonManagerDisplayStyle.COMPOSITE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ SET(AddonManagerResourceFilesIcons
     Resources/icons/document-python.svg
     Resources/icons/expanded_view.svg
     Resources/icons/process-stop.svg
+    Resources/icons/regex_bad.svg
+    Resources/icons/regex_ok.svg
     Resources/icons/sort_ascending.svg
     Resources/icons/sort_descending.svg
     Resources/icons/view-refresh.svg
@@ -196,7 +198,15 @@ SET(AddonManagerTestsGui_SRCS
     AddonManagerTest/gui/test_toolbar_adapter.py
     AddonManagerTest/gui/test_uninstaller_gui.py
     AddonManagerTest/gui/test_update_all_gui.py
+    AddonManagerTest/gui/test_widget_addon_buttons.py
+    AddonManagerTest/gui/test_widget_filter_selector.py
+    AddonManagerTest/gui/test_widget_global_buttons.py
+    AddonManagerTest/gui/test_widget_package_details_view.py
     AddonManagerTest/gui/test_widget_progress_bar.py
+    AddonManagerTest/gui/test_widget_readme_browser.py
+    AddonManagerTest/gui/test_widget_search.py
+    AddonManagerTest/gui/test_widget_view_control_bar.py
+    AddonManagerTest/gui/test_widget_view_selector.py
     AddonManagerTest/gui/test_workers_startup.py
     AddonManagerTest/gui/test_workers_utility.py
 )

--- a/Resources/icons/regex_bad.svg
+++ b/Resources/icons/regex_bad.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="px.svg"
+   viewBox="0 0 64 64">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3879"
+       inkscape:collect="always">
+      <stop
+         id="stop3881"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3883"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3869">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3871" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3873" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3869"
+       id="linearGradient3875"
+       x1="-45"
+       y1="1044.3622"
+       x2="-55"
+       y2="994.36218"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(80,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3879"
+       id="linearGradient3877"
+       x1="-45"
+       y1="1044.3622"
+       x2="-55"
+       y2="994.36218"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(80,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.278869"
+     inkscape:cx="-26.559982"
+     inkscape:cy="74.825919"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1598"
+     inkscape:window-height="836"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11521"
+       empspacing="2"
+       dotted="false"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-988.36218)">
+    <path
+       style="fill:none;stroke:#280000;stroke-width:16;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10,998.36218 44,44.00002"
+       id="path3002"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#280000;stroke-width:16;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 54,998.36218 10,1042.3622"
+       id="path3002-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#ef2929;stroke-width:12;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 10,998.36218 44,44.00002"
+       id="path3002-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#ef2929;stroke-width:12;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 54,998.36218 10,1042.3622"
+       id="path3002-6-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3877);stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 10,998.36218 44,44.00002"
+       id="path3002-7-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3875);stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 54,998.36218 10,1042.3622"
+       id="path3002-6-5-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/Resources/icons/regex_ok.svg
+++ b/Resources/icons/regex_ok.svg
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   id="svg2985"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="button_valid.svg">
+  <defs
+     id="defs2987">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3774">
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
+         offset="0"
+         id="stop3776" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="1"
+         id="stop3778" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4082"
+       id="linearGradient3922-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.56091264,-0.498646,0.48035179,-0.58227539,-177.89813,269.15635)"
+       x1="10.387"
+       y1="453.77875"
+       x2="56.319412"
+       y2="483.99524" />
+    <linearGradient
+       id="linearGradient4082">
+      <stop
+         id="stop4084"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop4086"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3774"
+       id="linearGradient3780"
+       x1="30"
+       y1="-2"
+       x2="26"
+       y2="-26"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3774"
+       id="linearGradient2999"
+       gradientUnits="userSpaceOnUse"
+       x1="30"
+       y1="-2"
+       x2="26"
+       y2="-26" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.696216"
+     inkscape:cx="42.681569"
+     inkscape:cy="45.101596"
+     inkscape:current-layer="g2995"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1600"
+     inkscape:window-height="837"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2983"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48)">
+    <g
+       id="g2995"
+       transform="matrix(1.2252683,0,0,1.2252683,-6.3014179,2.4330891)">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path4088"
+         d="m 15.48076,-21.246576 10.519239,10.519232 21.038474,-21.038464 7.889428,7.889424 L 25.999999,5.0515065 7.5913312,-13.357152 z"
+         style="fill:url(#linearGradient2999);fill-opacity:1;stroke:#172a04;stroke-width:1.63229537;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path3004"
+         d="M 9.9510978,-13.350403 15.477822,-18.889628 26,-8.4375583 47.031855,-29.448573 52.57108,-23.872581 26,2.7352662 z"
+         style="fill:none;stroke:#8ae234;stroke-width:1.63229549;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/Widgets/addonmanager_widget_addon_buttons.py
+++ b/Widgets/addonmanager_widget_addon_buttons.py
@@ -26,16 +26,7 @@
 from enum import Enum, auto
 import os
 
-try:
-    import FreeCAD
-
-    translate = FreeCAD.Qt.translate
-except ImportError:
-    FreeCAD = None
-
-    def translate(_: str, text: str):
-        return text
-
+from addonmanager_freecad_interface import translate
 
 from PySideWrapper import QtGui, QtWidgets
 

--- a/Widgets/addonmanager_widget_filter_selector.py
+++ b/Widgets/addonmanager_widget_filter_selector.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
-# *   Copyright (c) 2022-2024 FreeCAD Project Association                   *
+# *   Copyright (c) 2022-2025 The FreeCAD project association AISBL         *
 # *                                                                         *
-# *   This file is part of FreeCAD.                                         *
+# *   This file is part of the FreeCAD Addon Manager.                       *
 # *                                                                         *
 # *   FreeCAD is free software: you can redistribute it and/or modify it    *
 # *   under the terms of the GNU Lesser General Public License as           *
@@ -25,25 +25,9 @@
 
 from enum import IntEnum
 
-try:
-    import FreeCAD
+from addonmanager_freecad_interface import translate
 
-    translate = FreeCAD.Qt.translate
-except ImportError:
-    FreeCAD = None
-
-    def translate(_: str, text: str):
-        return text
-
-
-# Get whatever version of PySide we can
-try:
-    from PySide import QtCore, QtWidgets  # Use the FreeCAD wrapper
-except ImportError:
-    try:
-        from PySide6 import QtCore, QtWidgets  # Outside FreeCAD, try Qt6 first
-    except ImportError:
-        from PySide2 import QtCore, QtWidgets  # Fall back to Qt5
+from PySideWrapper import QtCore, QtWidgets
 
 
 class FilterType(IntEnum):

--- a/Widgets/addonmanager_widget_package_details_view.py
+++ b/Widgets/addonmanager_widget_package_details_view.py
@@ -26,22 +26,17 @@ from enum import Enum, auto
 import os
 from typing import Optional
 
-try:
-    import FreeCAD
-
-    translate = FreeCAD.Qt.translate
-except ImportError:
-    FreeCAD = None
-
-    def translate(_: str, text: str):
-        return text
-
+from addonmanager_freecad_interface import translate
 
 from PySideWrapper import QtCore, QtWidgets
 
 from .addonmanager_widget_addon_buttons import WidgetAddonButtons
 from .addonmanager_widget_readme_browser import WidgetReadmeBrowser
-from .addonmanager_colors import warning_color_string, attention_color_string, bright_color_string
+from .addonmanager_colors import (
+    warning_color_string,
+    attention_color_string,
+    bright_color_string,
+)
 
 
 class MessageType(Enum):
@@ -66,8 +61,8 @@ class WarningFlags:
     obsolete: bool = False
     python2: bool = False
     required_freecad_version: Optional[str] = None
-    non_osi_approved = False
-    non_fsf_libre = False
+    non_osi_approved: bool = False
+    non_fsf_libre: bool = False
 
 
 class PackageDetailsView(QtWidgets.QWidget):
@@ -136,7 +131,7 @@ class PackageDetailsView(QtWidgets.QWidget):
     def set_installed(
         self,
         installed: bool,
-        on_date: Optional[str] = None,
+        on_date: float = None,
         version: Optional[str] = None,
         branch: Optional[str] = None,
     ):
@@ -174,11 +169,13 @@ class PackageDetailsView(QtWidgets.QWidget):
 
         if disabled:
             message = translate(
-                "AddonsInstaller", "This Addon will be disabled next time you restart FreeCAD."
+                "AddonsInstaller",
+                "This Addon will be disabled next time you restart FreeCAD.",
             )
         else:
             message = translate(
-                "AddonsInstaller", "This Addon will be enabled next time you restart FreeCAD."
+                "AddonsInstaller",
+                "This Addon will be enabled next time you restart FreeCAD.",
             )
         self.message_label.setText(f"<h3>{message}</h3>")
         self.message_label.setStyleSheet("color:" + attention_color_string())
@@ -198,7 +195,8 @@ class PackageDetailsView(QtWidgets.QWidget):
         """If the user has just updated the addon but not yet restarted, show an indication that
         we are awaiting a restart."""
         message = translate(
-            "AddonsInstaller", "This Addon has been updated. Restart FreeCAD to see changes."
+            "AddonsInstaller",
+            "This Addon has been updated. Restart FreeCAD to see changes.",
         )
         self.message_label.setText(f"<h3>{message}</h3>")
         self.message_label.setStyleSheet("color:" + attention_color_string())
@@ -296,7 +294,8 @@ class PackageDetailsView(QtWidgets.QWidget):
                 if self.installed_branch != self.update_info.branch:
                     return (
                         translate(
-                            "AddonsInstaller", "Currently on branch {}, name changed to {}"
+                            "AddonsInstaller",
+                            "Currently on branch {}, name changed to {}",
                         ).format(self.installed_branch, self.update_info.branch)
                         + "."
                     )

--- a/Widgets/addonmanager_widget_search.py
+++ b/Widgets/addonmanager_widget_search.py
@@ -24,18 +24,9 @@
 """Defines a QWidget-derived class for displaying the view selection buttons."""
 
 import os
+from typing import Optional
 
-try:
-    import FreeCAD
-
-    translate = FreeCAD.Qt.translate
-except ImportError:
-    FreeCAD = None
-
-    def translate(_: str, text: str):
-        return text
-
-
+from addonmanager_freecad_interface import translate
 from PySideWrapper import QtCore, QtGui, QtWidgets
 
 
@@ -64,7 +55,7 @@ class WidgetSearch(QtWidgets.QWidget):
     def _setup_connections(self):
         self.filter_line_edit.textChanged.connect(self.set_text_filter)
 
-    def set_text_filter(self, text_filter: str) -> None:
+    def set_text_filter(self, text_filter: Optional[str]) -> None:
         """Set the current filter. If the filter is valid, this will emit a filter_changed
         signal. text_filter may be regular expression."""
 
@@ -76,21 +67,22 @@ class WidgetSearch(QtWidgets.QWidget):
                     translate("AddonsInstaller", "Filter is valid")
                 )
                 icon = QtGui.QIcon.fromTheme(
-                    "ok", QtGui.QIcon(os.path.join(icon_path, "edit_OK.svg"))
+                    "ok", QtGui.QIcon(os.path.join(icon_path, "regex_ok.svg"))
                 )
                 self.filter_validity_label.setPixmap(icon.pixmap(16, 16))
+                self.search_changed.emit(text_filter)
             else:
                 self.filter_validity_label.setToolTip(
                     translate("AddonsInstaller", "Filter regular expression is invalid")
                 )
                 icon = QtGui.QIcon.fromTheme(
-                    "ok", QtGui.QIcon(os.path.join(icon_path, "edit_Cancel.svg"))
+                    "cancel", QtGui.QIcon(os.path.join(icon_path, "regex_bad.svg"))
                 )
                 self.filter_validity_label.setPixmap(icon.pixmap(16, 16))
             self.filter_validity_label.show()
         else:
             self.filter_validity_label.hide()
-        self.search_changed.emit(text_filter)
+            self.search_changed.emit(text_filter)
 
     def retranslateUi(self, _):
         self.filter_line_edit.setPlaceholderText(


### PR DESCRIPTION
Many of these tests currently only serve to ensure that the code is exercised by the CI so it gets run by all supported versions of Python and Qt. In addition to adding the tests, this PR adjusts the code so they all pass.