### PR TITLE
Correct GuiUp check when outside FreeCAD

### DIFF
--- a/addonmanager_freecad_interface.py
+++ b/addonmanager_freecad_interface.py
@@ -107,7 +107,11 @@ except ImportError:
     try:
         from PySide6 import QtCore, QtWidgets
 
-        GuiUp = True if QtWidgets.QApplication.instance() else False
+        GuiUp = (
+            True
+            if hasattr(QtWidgets, "QApplication") and QtWidgets.QApplication.instance()
+            else False
+        )
         from PySide6.QtUiTools import QUiLoader
     except ImportError:
         try:


### PR DESCRIPTION
When the GUI is not running, QtWidgets doesn't even have a QApplication attribute to check.