### PR TITLE
Eliminate more unused imports

### DIFF
--- a/Addon.py
+++ b/Addon.py
@@ -25,7 +25,6 @@
 
 import os
 import re
-from datetime import datetime
 from urllib.parse import urlparse
 from typing import Dict, Set, List, Optional
 from threading import Lock

--- a/AddonManagerTest/app/test_utilities.py
+++ b/AddonManagerTest/app/test_utilities.py
@@ -27,11 +27,6 @@ from unittest.mock import MagicMock, patch, mock_open
 import os
 import subprocess
 
-try:
-    import FreeCAD
-except ImportError:
-    FreeCAD = None
-
 from AddonManagerTest.app.mocks import MockAddon as Addon
 
 from addonmanager_utilities import (

--- a/AddonManagerTest/gui/test_python_deps_gui.py
+++ b/AddonManagerTest/gui/test_python_deps_gui.py
@@ -4,14 +4,7 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
-try:
-    import FreeCAD
-    import FreeCADGui
-except ImportError:
-    try:
-        from PySide6 import QtCore, QtWidgets
-    except ImportError:
-        from PySide2 import QtCore, QtWidgets
+from PySideWrapper import QtCore, QtWidgets
 
 
 from addonmanager_python_deps_gui import (
@@ -21,7 +14,7 @@ from addonmanager_python_deps_gui import (
     python_package_updates_are_available,
     parse_pip_list_output,
 )
-from AddonManagerTest.gui.gui_mocks import DialogInteractor, DialogWatcher
+from AddonManagerTest.gui.gui_mocks import DialogWatcher
 
 
 class TestPythonPackageManager(unittest.TestCase):

--- a/AddonManagerTest/run_gui_tests.py
+++ b/AddonManagerTest/run_gui_tests.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 QApplication = None
 try:
     from PySide6 import QtCore, QtWidgets
-    from PySide6.QtWidgets import QApplication, QWidget
+    from PySide6.QtWidgets import QApplication
 
     pyside_version = 6
 except ImportError:

--- a/PySideWrapper.py
+++ b/PySideWrapper.py
@@ -31,3 +31,16 @@ except ImportError:
         from PySide6 import QtCore, QtGui, QtNetwork, QtSvg, QtWidgets
     except ImportError:
         from PySide2 import QtCore, QtGui, QtNetwork, QtSvg, QtWidgets
+
+# Dummy usage so the linter doesn't complain about the unused imports (since the whole point here is
+# that the imports aren't used in this file, they are just wrapped here)
+if hasattr(QtCore, "silence_the_linter"):
+    pass
+if hasattr(QtGui, "silence_the_linter"):
+    pass
+if hasattr(QtNetwork, "silence_the_linter"):
+    pass
+if hasattr(QtSvg, "silence_the_linter"):
+    pass
+if hasattr(QtWidgets, "silence_the_linter"):
+    pass

--- a/addonmanager_freecad_interface.py
+++ b/addonmanager_freecad_interface.py
@@ -43,6 +43,11 @@ try:
 
     try:
         from freecad.utils import get_python_exe
+
+        try:
+            _ = get_python_exe()
+        except AttributeError as e:
+            raise RuntimeError("Could not get the FreeCAD python executable") from e
     except ImportError:
         # This was only added in FreeCAD 1.0 -- to support FreeCAD 0.21 a backup strategy must be
         # used. This code is borrowed from FreeCAD 1.1dev.


### PR DESCRIPTION
In some cases by injecting dummy usages so that the linters stop warning on the places where the import is really intended for use in a different, chained, import.