### PR TITLE
Move detailed error message to box's details area

### DIFF
--- a/AddonManagerTest/gui/test_installer_gui.py
+++ b/AddonManagerTest/gui/test_installer_gui.py
@@ -69,9 +69,10 @@ class TestInstallerGui(unittest.TestCase):
             translate("AddonsInstaller", "Installation Failed"),
             QtWidgets.QDialogButtonBox.Cancel,
         )
-        self.installer_gui._installation_failed(
-            self.addon_to_install, "Test of installation failure"
-        )
+        message = "Some addon failed to install, so here is a really long error message that explains in excruciating detail exactly what has gone wrong."
+        for error_line in range(100):
+            message += f"\nError line {error_line}"
+        self.installer_gui._installation_failed(self.addon_to_install, message)
         self.assertTrue(dialog_watcher.dialog_found, "Failed to find the expected dialog box")
         self.assertTrue(dialog_watcher.button_found, "Failed to find the expected button")
 

--- a/addonmanager_installer_gui.py
+++ b/addonmanager_installer_gui.py
@@ -502,14 +502,15 @@ class AddonInstallerGUI(QtCore.QObject):
 
     def _installation_failed(self, addon, message):
         """Called if the installation failed."""
-        QtWidgets.QMessageBox.critical(
-            utils.get_main_am_window(),
-            translate("AddonsInstaller", "Installation Failed"),
+        error_dialog = QtWidgets.QMessageBox(utils.get_main_am_window())
+        error_dialog.setIcon(QtWidgets.QMessageBox.Critical)
+        error_dialog.setWindowTitle(translate("AddonsInstaller", "Installation Failed"))
+        error_dialog.setText(
             translate("AddonsInstaller", "Failed to install {}").format(addon.name)
-            + "\n"
-            + message,
-            QtWidgets.QMessageBox.Cancel,
         )
+        error_dialog.setStandardButtons(QtWidgets.QMessageBox.Cancel)
+        error_dialog.setDetailedText(message)
+        error_dialog.exec()
         self.finished.emit()
 
 


### PR DESCRIPTION
Fixes #45 by using the built-in "details" field of a `QMessageBox`. This necessitates manually creating and showing the box instead of using the static helper method, which increases code verbosity a little bit.