### PR TITLE
Correct installation of Resources files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ IF (BUILD_GUI)
     add_subdirectory(Widgets)
 ENDIF (BUILD_GUI)
 
+add_subdirectory(Resources)
+
 SET(AddonManager_SRCS
     ALLOWED_PYTHON_PACKAGES.txt
     Addon.py
@@ -81,91 +83,6 @@ IF (BUILD_GUI)
 ENDIF (BUILD_GUI)
 
 SOURCE_GROUP("" FILES ${AddonManager_SRCS})
-
-SET(AddonManagerResourceFilesIcons
-    Resources/icons/addon_manager.svg
-    Resources/icons/addon_manager_with_warning.svg
-    Resources/icons/button_left.svg
-    Resources/icons/button_valid.svg
-    Resources/icons/compact_view.svg
-    Resources/icons/composite_view.svg
-    Resources/icons/debug-stop.svg
-    Resources/icons/document-package.svg
-    Resources/icons/document-python.svg
-    Resources/icons/expanded_view.svg
-    Resources/icons/process-stop.svg
-    Resources/icons/regex_bad.svg
-    Resources/icons/regex_ok.svg
-    Resources/icons/sort_ascending.svg
-    Resources/icons/sort_descending.svg
-    Resources/icons/view-refresh.svg
-)
-
-SET(AddonManagerResourceFilesTranslations
-    Resources/translations/AddonManager_af.qm
-    Resources/translations/AddonManager_ar.qm
-    Resources/translations/AddonManager_be.qm
-    Resources/translations/AddonManager_bg.qm
-    Resources/translations/AddonManager_ca.qm
-    Resources/translations/AddonManager_cs.qm
-    Resources/translations/AddonManager_da.qm
-    Resources/translations/AddonManager_de.qm
-    Resources/translations/AddonManager_el.qm
-    Resources/translations/AddonManager_es-AR.qm
-    Resources/translations/AddonManager_es-ES.qm
-    Resources/translations/AddonManager_eu.qm
-    Resources/translations/AddonManager_fi.qm
-    Resources/translations/AddonManager_fil.qm
-    Resources/translations/AddonManager_fr.qm
-    Resources/translations/AddonManager_gl.qm
-    Resources/translations/AddonManager_hr.qm
-    Resources/translations/AddonManager_hu.qm
-    Resources/translations/AddonManager_id.qm
-    Resources/translations/AddonManager_it.qm
-    Resources/translations/AddonManager_ja.qm
-    Resources/translations/AddonManager_ka.qm
-    Resources/translations/AddonManager_kab.qm
-    Resources/translations/AddonManager_ko.qm
-    Resources/translations/AddonManager_lt.qm
-    Resources/translations/AddonManager_nl.qm
-    Resources/translations/AddonManager_no.qm
-    Resources/translations/AddonManager_pl.qm
-    Resources/translations/AddonManager_pt-BR.qm
-    Resources/translations/AddonManager_pt-PT.qm
-    Resources/translations/AddonManager_ro.qm
-    Resources/translations/AddonManager_ru.qm
-    Resources/translations/AddonManager_sk.qm
-    Resources/translations/AddonManager_sl.qm
-    Resources/translations/AddonManager_sr-CS.qm
-    Resources/translations/AddonManager_sr.qm
-    Resources/translations/AddonManager_sv-SE.qm
-    Resources/translations/AddonManager_tr.qm
-    Resources/translations/AddonManager_uk.qm
-    Resources/translations/AddonManager_val-ES.qm
-    Resources/translations/AddonManager_vi.qm
-    Resources/translations/AddonManager_zh-CN.qm
-    Resources/translations/AddonManager_zh-TW.qm
-)
-
-SET(AddonManagerResourceFilesLicenses
-    Resources/licenses/Apache-2.0.txt
-    Resources/licenses/BSD-2-Clause.txt
-    Resources/licenses/BSD-3-Clause.txt
-    Resources/licenses/CC0-1.0.txt
-    Resources/licenses/GPL-2.0-or-later.txt
-    Resources/licenses/GPL-3.0-or-later.txt
-    Resources/licenses/LGPL-2.1-or-later.txt
-    Resources/licenses/LGPL-3.0-or-later.txt
-    Resources/licenses/MIT.txt
-    Resources/licenses/MPL-2.0.txt
-    Resources/licenses/spdx.json
-)
-
-LIST(APPEND AddonManager_SRCS
-    ${AddonManagerResourceFilesIcons}
-    ${AddonManagerResourceFilesLicenses}
-    ${AddonManagerResourceFilesTranslations}
-)
 
 SET(AddonManagerTests_SRCS
     AddonManagerTest/__init__.py

--- a/Resources/CMakeLists.txt
+++ b/Resources/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(icons)
+add_subdirectory(licenses)
+add_subdirectory(translations)

--- a/Resources/icons/CMakeLists.txt
+++ b/Resources/icons/CMakeLists.txt
@@ -1,0 +1,28 @@
+SET(AddonManagerResourceFilesIcons
+    addon_manager.svg
+    addon_manager_with_warning.svg
+    button_left.svg
+    button_valid.svg
+    compact_view.svg
+    composite_view.svg
+    debug-stop.svg
+    document-package.svg
+    document-python.svg
+    expanded_view.svg
+    gear.svg
+    preferences-addon_manager.svg
+    process-stop.svg
+    regex_bad.svg
+    regex_ok.svg
+    sort_ascending.svg
+    sort_descending.svg
+    view-refresh.svg
+)
+
+ADD_CUSTOM_TARGET(AddonManagerIcons ALL
+    SOURCES ${AddonManagerResourceFilesIcons}
+)
+
+fc_copy_sources(AddonManagerIcons "${CMAKE_BINARY_DIR}/Mod/AddonManager/Resources/icons" ${AddonManagerResourceFilesIcons})
+
+INSTALL(FILES ${AddonManagerResourceFilesIcons} DESTINATION Mod/AddonManager/Resources/icons)

--- a/Resources/licenses/CMakeLists.txt
+++ b/Resources/licenses/CMakeLists.txt
@@ -1,0 +1,21 @@
+SET(AddonManagerResourceFilesLicenses
+    Apache-2.0.txt
+    BSD-2-Clause.txt
+    BSD-3-Clause.txt
+    CC0-1.0.txt
+    GPL-2.0-or-later.txt
+    GPL-3.0-or-later.txt
+    LGPL-2.1-or-later.txt
+    LGPL-3.0-or-later.txt
+    MIT.txt
+    MPL-2.0.txt
+    spdx.json
+)
+
+ADD_CUSTOM_TARGET(AddonManagerLicenses ALL
+    SOURCES ${AddonManagerResourceFilesLicenses}
+)
+
+fc_copy_sources(AddonManagerLicenses "${CMAKE_BINARY_DIR}/Mod/AddonManager/Resources/licenses" ${AddonManagerResourceFilesLicenses})
+
+INSTALL(FILES ${AddonManagerResourceFilesLicenses} DESTINATION Mod/AddonManager/Resources/licenses)

--- a/Resources/translations/CMakeLists.txt
+++ b/Resources/translations/CMakeLists.txt
@@ -1,0 +1,53 @@
+SET(AddonManagerResourceFilesTranslations
+    AddonManager_af.qm
+    AddonManager_ar.qm
+    AddonManager_be.qm
+    AddonManager_bg.qm
+    AddonManager_ca.qm
+    AddonManager_cs.qm
+    AddonManager_da.qm
+    AddonManager_de.qm
+    AddonManager_el.qm
+    AddonManager_es-AR.qm
+    AddonManager_es-ES.qm
+    AddonManager_eu.qm
+    AddonManager_fi.qm
+    AddonManager_fil.qm
+    AddonManager_fr.qm
+    AddonManager_gl.qm
+    AddonManager_hr.qm
+    AddonManager_hu.qm
+    AddonManager_id.qm
+    AddonManager_it.qm
+    AddonManager_ja.qm
+    AddonManager_ka.qm
+    AddonManager_kab.qm
+    AddonManager_ko.qm
+    AddonManager_lt.qm
+    AddonManager_nl.qm
+    AddonManager_no.qm
+    AddonManager_pl.qm
+    AddonManager_pt-BR.qm
+    AddonManager_pt-PT.qm
+    AddonManager_ro.qm
+    AddonManager_ru.qm
+    AddonManager_sk.qm
+    AddonManager_sl.qm
+    AddonManager_sr-CS.qm
+    AddonManager_sr.qm
+    AddonManager_sv-SE.qm
+    AddonManager_tr.qm
+    AddonManager_uk.qm
+    AddonManager_val-ES.qm
+    AddonManager_vi.qm
+    AddonManager_zh-CN.qm
+    AddonManager_zh-TW.qm
+)
+
+ADD_CUSTOM_TARGET(AddonManagerTranslations ALL
+    SOURCES ${AddonManagerResourceFilesTranslations}
+)
+
+fc_copy_sources(AddonManagerTranslations "${CMAKE_BINARY_DIR}/Mod/AddonManager/Resources/translations" ${AddonManagerResourceFilesTranslations})
+
+INSTALL(FILES ${AddonManagerResourceFilesTranslations} DESTINATION Mod/AddonManager/Resources/translations)


### PR DESCRIPTION
When transitioning away from using the Qt resources system, the CMake setup for the resources files got broken. This doesn't affect the Addon Manager installed as an Addon, but breaks the copy that gets installed with FreeCAD. Refactor the Addon Manager's CMake scripts to ensure those files are correctly installed. Fixes #100.