### PR TITLE
Correct cache output dictionary

### DIFF
--- a/AddonCatalog.py
+++ b/AddonCatalog.py
@@ -87,13 +87,15 @@ class AddonCatalogEntry:
             if hasattr(self, key):
                 if key in ("freecad_min", "freecad_max"):
                     value = Version(from_string=value)
-                elif key == "metadata" and isinstance(value, str):
-                    value = CatalogEntryMetadata.from_dict(json.loads(value))
-                elif key == "git_ref":
-                    if self.branch_display_name is None:
-                        # The branch display name defaults to the git ref if it doesn't get set
-                        # explicitly
-                        self.branch_display_name = value
+                elif key == "metadata":
+                    if isinstance(value, dict):
+                        metadata = CatalogEntryMetadata()
+                        metadata.__dict__.update(value)
+                        value = metadata
+                    elif isinstance(value, str):
+                        value = CatalogEntryMetadata.from_dict(json.loads(value))
+                elif key == "git_ref" and self.branch_display_name is None:
+                    self.branch_display_name = value
                 setattr(self, key, value)
 
     def is_compatible(self) -> bool:

--- a/AddonCatalogCacheCreator.py
+++ b/AddonCatalogCacheCreator.py
@@ -55,7 +55,7 @@ EXCLUDED_REPOS = ["parts_library"]
 
 def recursive_serialize(obj: Any):
     """Recursively serialize an object, supporting non-dataclasses that themselves contain
-    dataclasses  (in this case, AddonCatalog, which contains AddonCatalogEntry)"""
+    dataclasses (in this case, AddonCatalog, which contains AddonCatalogEntry)"""
     if is_dataclass(obj):
         result = {}
         for f in fields(obj):
@@ -67,7 +67,7 @@ def recursive_serialize(obj: Any):
     elif isinstance(obj, dict):
         return {k: recursive_serialize(v) for k, v in obj.items()}
     elif hasattr(obj, "__dict__"):
-        return {k: recursive_serialize(v) for k, v in vars(obj).items() if not k.startswith("_")}
+        return {k: recursive_serialize(v) for k, v in vars(obj).items() if not k.startswith("__")}
     else:
         return obj
 
@@ -122,7 +122,10 @@ class CacheWriter:
         with zipfile.ZipFile(
             os.path.join(self.cwd, "addon_catalog_cache.zip"), "w", zipfile.ZIP_DEFLATED
         ) as zipf:
-            zipf.writestr("cache.json", json.dumps(recursive_serialize(self.catalog), indent="  "))
+            zipf.writestr(
+                "cache.json",
+                json.dumps(recursive_serialize(self.catalog.get_catalog()), indent="  "),
+            )
 
         # Also generate the sha256 hash of the zip file and store it
         with open("addon_catalog_cache.zip", "rb") as cache_file:

--- a/AddonManagerTest/app/test_addon_catalog_cache_creator.py
+++ b/AddonManagerTest/app/test_addon_catalog_cache_creator.py
@@ -93,6 +93,22 @@ class TestRecursiveSerialize(TestCase):
         result = accc.recursive_serialize(instance)
         self.assertDictEqual(result, {"a": {"a": 0, "b": "b", "c": 1.0}})
 
+    def test_real_catalog(self):
+        catalog_dict = {
+            "TestMod1": [
+                {"repository": "https://some.url", "git_ref": "branch-1"},
+                {"repository": "https://some.url", "git_ref": "branch-2"},
+            ],
+            "TestMod2": [
+                {"zip_url": "zip1"},
+                {"zip_url": "zip2"},
+            ],
+        }
+        catalog = AddonCatalog.AddonCatalog(catalog_dict)
+        result = accc.recursive_serialize(catalog.get_catalog())
+        self.assertIn("TestMod1", result)
+        self.assertIn("TestMod2", result)
+
 
 class TestCacheWriter(TestCase):
 


### PR DESCRIPTION
When trying to output the cache, only output the inner dictionary of the catalog, not all the other auxiliary data.