### PR TITLE
Add support for local filesystem repos

### DIFF
--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -91,7 +91,7 @@ class ReadmeController(QtCore.QObject):
                 self.addon.display_name, self.url
             )
         )
-        if self.url[0]:
+        if self.url[0] == '/':
             if self.url[:3] == '.md':
                 self.readme_data_type = ReadmeDataType.Markdown
             elif self.url[:5] == '.html':

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -98,7 +98,8 @@ class ReadmeController(QtCore.QObject):
             elif self.url[:5] == ".html":
                 self.readme_data_type = ReadmeDataType.Html
 
-            self._process_package_download("".join(open(self.url, "r").readlines()))
+            with open(self.url, "r") as fd:
+              self._process_package_download("".join(fd.readlines()))
         else:
             self.readme_request_index = NetworkManager.AM_NETWORK_MANAGER.submit_unmonitored_get(
                 self.url

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -99,7 +99,7 @@ class ReadmeController(QtCore.QObject):
                 self.readme_data_type = ReadmeDataType.Html
 
             with open(self.url, "r") as fd:
-              self._process_package_download("".join(fd.readlines()))
+                self._process_package_download("".join(fd.readlines()))
         else:
             self.readme_request_index = NetworkManager.AM_NETWORK_MANAGER.submit_unmonitored_get(
                 self.url

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -90,6 +90,8 @@ class ReadmeController(QtCore.QObject):
             translate("AddonsInstaller", "Loading page for {} from {}...").format(
                 self.addon.display_name, self.url
             )
+        )
+
         if self.url[0] == "/":
             if self.url[:3] == ".md":
                 self.readme_data_type = ReadmeDataType.Markdown

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -91,9 +91,17 @@ class ReadmeController(QtCore.QObject):
                 self.addon.display_name, self.url
             )
         )
-        self.readme_request_index = NetworkManager.AM_NETWORK_MANAGER.submit_unmonitored_get(
-            self.url
-        )
+        if self.url[0]:
+            if self.url[:3] == '.md':
+                self.readme_data_type = ReadmeDataType.Markdown
+            elif self.url[:5] == '.html':
+                self.readme_data_type = ReadmeDataType.Html
+
+            self._process_package_download(''.join(open(self.url, 'r').readlines()))
+        else:
+            self.readme_request_index = NetworkManager.AM_NETWORK_MANAGER.submit_unmonitored_get(
+                self.url
+            )
 
     def _download_completed(self, index: int, code: int, data: QtCore.QByteArray) -> None:
         """Callback for handling a completed README file download."""

--- a/addonmanager_utilities.py
+++ b/addonmanager_utilities.py
@@ -243,6 +243,8 @@ def construct_git_url(repo, filename):
         return f"{repo_url}/-/raw/{repo.branch}/{filename}"
     if parsed_url.netloc in ["codeberg.org"]:
         return f"{repo_url}/raw/branch/{repo.branch}/{filename}"
+    if parsed_url.netloc == '':
+        return f"{parsed_url.path}/{filename}"
     fci.Console.PrintLog(
         "Debug: addonmanager_utilities.construct_git_url: Unknown git host:"
         + parsed_url.netloc


### PR DESCRIPTION
Quick and small patch that adds support for local filesystem URLs. I couldn't determine another way to do this, and prior to this it would return in trying to fetch `/path/to/real_repo/-/raw/branch/README.md`, this patch removes the `raw/branch` portion of the URL. Then in the fetch portion, if the url start wtih `/` it will get treated like a local file.

The preferences already accepted a local path but in this case the branch would be ignored.