### PR TITLE
Correct thread the deps installer GUI runs on

### DIFF
--- a/AddonManagerTest/gui/test_installer_gui.py
+++ b/AddonManagerTest/gui/test_installer_gui.py
@@ -127,11 +127,9 @@ class TestAddonInstallerGUI(unittest.TestCase):
         # Act
         installer = AddonInstallerGUI(test_addon)
         installer.run()
-        mock_dep_gui_instance.run()
 
         # Assert
         self.assertTrue(mock_dep_gui_instance.called)
-        self.assertTrue(mock_dep_gui_instance.moved_to_thread)
 
         installer.shutdown()
 
@@ -158,7 +156,6 @@ class TestAddonInstallerGUI(unittest.TestCase):
 
         # Act
         installer.run()
-        mock_dep_gui_instance.run()
 
         # Assert
         mock_install.assert_called_once()

--- a/addonmanager_installer_gui.py
+++ b/addonmanager_installer_gui.py
@@ -68,7 +68,6 @@ class AddonInstallerGUI(QtCore.QObject):
         self.dependency_installer = None
         self.install_worker = None
         self.dependency_dialog = None
-        self.dependency_worker_thread = None
         self.dependency_installation_dialog = None
         self.installing_dialog = None
         self.worker_thread = None
@@ -80,7 +79,6 @@ class AddonInstallerGUI(QtCore.QObject):
     def shutdown(self):
         try:
             self._stop_thread(self.worker_thread)
-            self._stop_thread(self.dependency_worker_thread)
         except RuntimeError:
             # In some circumstances during shutdown the underlying C++ thread may already be gone:
             # we don't care
@@ -115,13 +113,7 @@ class AddonInstallerGUI(QtCore.QObject):
         self.dependency_installer = AddonDependencyInstallerGUI([self.addon_to_install], deps)
         self.dependency_installer.cancel.connect(self.finished.emit)
         self.dependency_installer.proceed.connect(self.install)
-        self.dependency_worker_thread = QtCore.QThread(self)
-        self.dependency_worker_thread.setObjectName("AddonDependencyInstallerGUI worker thread")
-        self.dependency_installer.moveToThread(self.dependency_worker_thread)
-        self.dependency_worker_thread.started.connect(self.dependency_installer.run)
-        self.dependency_installer.cancel.connect(self.dependency_worker_thread.quit)
-        self.dependency_installer.proceed.connect(self.dependency_worker_thread.quit)
-        self.dependency_worker_thread.start()
+        self.dependency_installer.run()
 
     def install(self) -> None:
         """Installs or updates a workbench, macro, or package"""

--- a/package.xml
+++ b/package.xml
@@ -5,8 +5,8 @@
     <name>Addon Manager</name>
     <description>Tool to install workbenches, macros, themes, etc.</description>
     <icon>Resources/icons/addon_manager.svg</icon>
-    <version>2025.08.04</version>
-    <date>2025-08-04</date>
+    <version>2025.08.05</version>
+    <date>2025-08-05</date>
     <maintainer email='chennes@freecad.org'>Chris Hennes</maintainer>
     <author email = 'yorik@uncreated.net'>Yorik van Havre</author>
     <author>Jonathan Wiedemann</author>


### PR DESCRIPTION
This is a GUI, it must run on the main thread. The GUI then spawns sub-threads that manage the actual update process.