### PR TITLE
Fix missing CMake entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,154 +5,77 @@ ENDIF (BUILD_GUI)
 add_subdirectory(Resources)
 
 SET(AddonManager_SRCS
-    ALLOWED_PYTHON_PACKAGES.txt
-    Addon.py
-    AddonManager.py
-    AddonManager.ui
-    AddonCatalog.py
-    AddonManagerOptions.py
-    AddonManagerOptions.ui
-    AddonManagerOptions_AddCustomRepository.ui
-    AddonStats.py
-    Init.py
-    InitGui.py
-    NetworkManager.py
-    PySideWrapper.py
-    PythonDependencyUpdateDialog.ui
-    TestAddonManagerApp.py
+    __init__.py
     add_toolbar_button_dialog.ui
+    Addon.py
+    AddonCatalog.py
+    AddonCatalog.schema.json
+    AddonCatalogCacheCreator.py
     addonmanager_connection_checker.py
     addonmanager_dependency_installer.py
     addonmanager_firstrun.py
     addonmanager_freecad_interface.py
     addonmanager_git.py
-    addonmanager_installer.py
+    addonmanager_installation_manifest.py
     addonmanager_installer_gui.py
+    addonmanager_installer.py
     addonmanager_licenses.py
-    addonmanager_macro.py
     addonmanager_macro_parser.py
+    addonmanager_macro.py
     addonmanager_metadata.py
     addonmanager_package_details_controller.py
     addonmanager_preferences_defaults.json
-    addonmanager_python_deps.py
     addonmanager_python_deps_gui.py
+    addonmanager_python_deps.py
     addonmanager_readme_controller.py
     addonmanager_toolbar_adapter.py
-    addonmanager_uninstaller.py
     addonmanager_uninstaller_gui.py
+    addonmanager_uninstaller.py
     addonmanager_update_all_gui.py
     addonmanager_utilities.py
     addonmanager_workers_startup.py
     addonmanager_workers_utility.py
+    addonmanager.dox
+    AddonManager.py
+    AddonManager.ui
+    AddonManagerOptions_AddCustomRepository.ui
+    AddonManagerOptions.py
+    AddonManagerOptions.ui
+    AddonStats.py
+    ALLOWED_PYTHON_PACKAGES.txt
     compact_view.py
+    compact_view.ui
     composite_view.py
     dependency_resolution_dialog.ui
     expanded_view.py
+    expanded_view.ui
     first_run.ui
-    package.xml
+    Init.py
+    InitGui.py
+    LICENSE.md
+    MacroCacheCreator.py
+    NetworkManager.py
+    package_details.ui
     package_list.py
+    package.xml
+    progress.ui
+    proxy_authentication.ui
+    PySideWrapper.py
+    PythonDependencyUpdateDialog.ui
     select_toolbar_dialog.ui
+    TestAddonManagerApp.py
+    TestAddonManagerGui.py
+    toolbar_button.ui
+    update_all_progress.ui
     update_all.ui
 )
-IF (BUILD_GUI)
-	LIST(APPEND AddonManager_SRCS TestAddonManagerGui.py)
-ENDIF (BUILD_GUI)
 
 SOURCE_GROUP("" FILES ${AddonManager_SRCS})
-
-SET(AddonManagerTests_SRCS
-    AddonManagerTest/__init__.py
-    AddonManagerTest/test_information.md
-)
-
-SET(AddonManagerTestsApp_SRCS
-    AddonManagerTest/app/__init__.py
-    AddonManagerTest/app/mocks.py
-    AddonManagerTest/app/test_addon.py
-    AddonManagerTest/app/test_addoncatalog.py
-    AddonManagerTest/app/test_dependency_installer.py
-    AddonManagerTest/app/test_freecad_interface.py
-    AddonManagerTest/app/test_git.py
-    AddonManagerTest/app/test_installer.py
-    AddonManagerTest/app/test_macro.py
-    AddonManagerTest/app/test_macro_parser.py
-    AddonManagerTest/app/test_metadata.py
-    AddonManagerTest/app/test_uninstaller.py
-    AddonManagerTest/app/test_utilities.py
-    AddonManagerTest/app/test_workers_startup.py
-)
-
-SET(AddonManagerTestsGui_SRCS
-    AddonManagerTest/gui/__init__.py
-    AddonManagerTest/gui/gui_mocks.py
-    AddonManagerTest/gui/test_installer_gui.py
-    AddonManagerTest/gui/test_python_deps_gui.py
-    AddonManagerTest/gui/test_toolbar_adapter.py
-    AddonManagerTest/gui/test_uninstaller_gui.py
-    AddonManagerTest/gui/test_update_all_gui.py
-    AddonManagerTest/gui/test_widget_addon_buttons.py
-    AddonManagerTest/gui/test_widget_filter_selector.py
-    AddonManagerTest/gui/test_widget_global_buttons.py
-    AddonManagerTest/gui/test_widget_package_details_view.py
-    AddonManagerTest/gui/test_widget_progress_bar.py
-    AddonManagerTest/gui/test_widget_readme_browser.py
-    AddonManagerTest/gui/test_widget_search.py
-    AddonManagerTest/gui/test_widget_view_control_bar.py
-    AddonManagerTest/gui/test_widget_view_selector.py
-    AddonManagerTest/gui/test_workers_utility.py
-)
-
-SET(AddonManagerTestsFiles_SRCS
-        AddonManagerTest/data/__init__.py
-        AddonManagerTest/data/addon_update_stats.json
-        AddonManagerTest/data/bundle_only.xml
-        AddonManagerTest/data/combination.xml
-        AddonManagerTest/data/corrupted_metadata.zip
-        AddonManagerTest/data/depends_on_all_workbenches.xml
-        AddonManagerTest/data/DoNothing.FCMacro
-        AddonManagerTest/data/git_submodules.txt
-        AddonManagerTest/data/good_package.xml
-        AddonManagerTest/data/icon_cache.zip
-        AddonManagerTest/data/icon_cache.zip.sha1
-        AddonManagerTest/data/macro_only.xml
-        AddonManagerTest/data/macro_template.FCStd
-        AddonManagerTest/data/MacrosRecipesWikiPage.zip
-        AddonManagerTest/data/metadata.zip
-        AddonManagerTest/data/missing_macro_metadata.FCStd
-        AddonManagerTest/data/other_only.xml
-        AddonManagerTest/data/prefpack_only.xml
-        AddonManagerTest/data/test_addon_with_fcmacro.zip
-        AddonManagerTest/data/test_github_style_repo.zip
-        AddonManagerTest/data/test_repo.zip
-        AddonManagerTest/data/test_simple_repo.zip
-        AddonManagerTest/data/test_version_detection.xml
-        AddonManagerTest/data/TestWorkbench.zip
-        AddonManagerTest/data/workbench_only.xml
-)
-
-SET(AddonManagerTests_ALL
-    ${AddonManagerTests_SRCS}
-    ${AddonManagerTestsApp_SRCS}
-    ${AddonManagerTestsFiles_SRCS}
-	)
-
-IF (BUILD_GUI)
-    LIST(APPEND AddonManagerTests_ALL ${AddonManagerTestsGui_SRCS})
-ENDIF (BUILD_GUI)
 
 ADD_CUSTOM_TARGET(AddonManager ALL
     SOURCES ${AddonManager_SRCS}
 )
 
-ADD_CUSTOM_TARGET(AddonManagerTests ALL
-    SOURCES ${AddonManagerTests_ALL}
-)
-
 fc_copy_sources(AddonManager "${CMAKE_BINARY_DIR}/Mod/AddonManager" ${AddonManager_SRCS})
-fc_copy_sources(AddonManagerTests "${CMAKE_BINARY_DIR}/Mod/AddonManager" ${AddonManagerTests_ALL})
 
 INSTALL(FILES ${AddonManager_SRCS} DESTINATION Mod/AddonManager)
-INSTALL(FILES ${AddonManagerTests_SRCS} DESTINATION Mod/AddonManager/AddonManagerTest)
-INSTALL(FILES ${AddonManagerTestsApp_SRCS} DESTINATION Mod/AddonManager/AddonManagerTest/app)
-INSTALL(FILES ${AddonManagerTestsGui_SRCS} DESTINATION Mod/AddonManager/AddonManagerTest/gui)
-INSTALL(FILES ${AddonManagerTestsFiles_SRCS} DESTINATION Mod/AddonManager/AddonManagerTest/data)

--- a/Widgets/CMakeLists.txt
+++ b/Widgets/CMakeLists.txt
@@ -1,15 +1,16 @@
 SET(AddonManagerWidget_SRCS
-        __init__.py
-        addonmanager_colors.py
-        addonmanager_widget_addon_buttons.py
-        addonmanager_widget_filter_selector.py
-        addonmanager_widget_global_buttons.py
-        addonmanager_widget_package_details_view.py
-        addonmanager_widget_progress_bar.py
-        addonmanager_widget_readme_browser.py
-        addonmanager_widget_search.py
-        addonmanager_widget_view_control_bar.py
-        addonmanager_widget_view_selector.py
+    __init__.py
+    addonmanager_colors.py
+    addonmanager_utility_dialogs.py
+    addonmanager_widget_addon_buttons.py
+    addonmanager_widget_filter_selector.py
+    addonmanager_widget_global_buttons.py
+    addonmanager_widget_package_details_view.py
+    addonmanager_widget_progress_bar.py
+    addonmanager_widget_readme_browser.py
+    addonmanager_widget_search.py
+    addonmanager_widget_view_control_bar.py
+    addonmanager_widget_view_selector.py
 )
 
 SOURCE_GROUP("" FILES ${AddonManagerWidget_SRCS})


### PR DESCRIPTION
Also removes all testing files from CMake -- the tests are designed to run standalone, not within FreeCAD's testing framework.