### PR TITLE
Add progress spinner while checking single addon

### DIFF
--- a/Resources/icons/CMakeLists.txt
+++ b/Resources/icons/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(AddonManagerResourceFilesIcons
     regex_ok.svg
     sort_ascending.svg
     sort_descending.svg
+    spinner.svg
     view-refresh.svg
 )
 

--- a/Resources/icons/spinner.svg
+++ b/Resources/icons/spinner.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 64 64">
+  <defs>
+    <style>
+      .st0 {
+        fill: none;
+        stroke-width: 7px;
+      }
+
+      .st0, .st1 {
+        stroke: #231f20;
+        stroke-miterlimit: 10;
+      }
+
+      .st1 {
+        fill: #231f20;
+      }
+    </style>
+  </defs>
+  <g>
+    <polygon class="st1" points="16.28 32.12 3.63 32.12 9.95 44.77 16.28 32.12"/>
+    <path class="st0" d="M9.67,31.75c0-12.26,10.09-22.36,22.36-22.36,3.92,0,7.78,1.03,11.18,3"/>
+  </g>
+  <g>
+    <polygon class="st1" points="47.96 32.31 60.61 32.31 54.29 19.66 47.96 32.31"/>
+    <path class="st0" d="M54.58,32.68c0,12.26-10.09,22.36-22.36,22.36-3.92,0-7.78-1.03-11.18-3"/>
+  </g>
+</svg>

--- a/Widgets/CMakeLists.txt
+++ b/Widgets/CMakeLists.txt
@@ -11,6 +11,7 @@ SET(AddonManagerWidget_SRCS
     addonmanager_widget_search.py
     addonmanager_widget_view_control_bar.py
     addonmanager_widget_view_selector.py
+    spinner.py
 )
 
 SOURCE_GROUP("" FILES ${AddonManagerWidget_SRCS})

--- a/Widgets/addonmanager_widget_addon_buttons.py
+++ b/Widgets/addonmanager_widget_addon_buttons.py
@@ -30,6 +30,7 @@ from typing import List
 from addonmanager_freecad_interface import translate
 
 from PySideWrapper import QtCore, QtGui, QtWidgets
+from Widgets.spinner import Spinner
 
 
 class WidgetAddonButtons(QtWidgets.QWidget):
@@ -49,6 +50,9 @@ class WidgetAddonButtons(QtWidgets.QWidget):
     def set_update_available(self, update_available: bool):
         """Set the update availability."""
         self.update.setVisible(update_available)
+
+    def set_update_check_status(self, checking: bool):
+        self.spinner.setVisible(checking)
 
     def set_installation_status(
         self,
@@ -136,10 +140,10 @@ class WidgetAddonButtons(QtWidgets.QWidget):
         self.disable = QtWidgets.QPushButton(self)
         self.update = QtWidgets.QPushButton(self)
         self.run_macro = QtWidgets.QPushButton(self)
-        self.check_for_update = QtWidgets.QPushButton(self)
+        self.spinner = Spinner(self)
         self.horizontal_layout.addWidget(self.back)
         self.horizontal_layout.addStretch()
-        self.horizontal_layout.addWidget(self.check_for_update)
+        self.horizontal_layout.addWidget(self.spinner)
         self.horizontal_layout.addWidget(self.install)
         self.horizontal_layout.addWidget(self.uninstall)
         self.horizontal_layout.addWidget(self.enable)
@@ -158,7 +162,6 @@ class WidgetAddonButtons(QtWidgets.QWidget):
         )
 
     def retranslateUi(self, _):
-        self.check_for_update.setText(translate("AddonsInstaller", "Check for Update"))
         if self.setup_to_change_branch:
             self.install.setText(translate("AddonsInstaller", "Switch to Branch"))
         elif self.is_addon_manager:
@@ -170,6 +173,7 @@ class WidgetAddonButtons(QtWidgets.QWidget):
         self.update.setText(translate("AddonsInstaller", "Update"))
         self.run_macro.setText(translate("AddonsInstaller", "Run"))
         self.back.setToolTip(translate("AddonsInstaller", "Return to Package List"))
+        self.spinner.setToolTip(translate("AddonsInstaller", "Checking for Updates…"))
         if self.is_addon_manager:
             self.uninstall.setText(translate("AddonsInstaller", "Revert to Built-In"))
         else:

--- a/Widgets/spinner.py
+++ b/Widgets/spinner.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 The FreeCAD project association AISBL              *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+import os
+
+from PySideWrapper import QtCore, QtGui, QtWidgets, QtSvg
+
+
+class Spinner(QtWidgets.QWidget):
+
+    def __init__(self, parent=None, fps=60, speed_deg_per_sec=180):
+        super().__init__(parent)
+        spinner_file = os.path.join(
+            os.path.dirname(__file__), "..", "Resources", "icons", "spinner.svg"
+        )
+        self._renderer = QtSvg.QSvgRenderer(spinner_file, self)
+        self._angle = 0.0
+        self._speed = float(speed_deg_per_sec)
+
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(max(1, int(1000.0 / float(fps))))
+        self._timer.timeout.connect(self._on_tick)
+        self._timer.start()
+
+    def sizeHint(self):
+        ds = self._renderer.defaultSize()
+        return ds if ds.isValid() else QtCore.QSize(64, 64)
+
+    def minimumSizeHint(self):
+        return QtCore.QSize(16, 16)
+
+    def _on_tick(self):
+        dt = self._timer.interval() / 1000.0
+        self._angle = (self._angle - self._speed * dt) % 360.0
+        self.update()
+
+    def _effective_bg_color(self) -> QtGui.QColor:
+        """This is a bit heuristic, we just try to find our first non-background parent. If a
+        stylesheet is set, use that."""
+        w = self
+        while w is not None:
+            col = w.palette().window().color()
+            if col.isValid() and col.alpha() > 0:
+                return col
+            w = w.parentWidget()
+        return self.palette().window().color()
+
+    def _pick_fg(self) -> QtGui.QColor:
+        bg = self._effective_bg_color()
+        # White has a higher contrast than black if L < 0.179
+        return (
+            QtGui.QColor(QtCore.Qt.white)
+            if _srgb_luminance(bg) < 0.179
+            else QtGui.QColor(QtCore.Qt.black)
+        )
+
+    def paintEvent(self, _evt):
+        if not self._renderer.isValid():
+            return
+        p = QtGui.QPainter(self)
+        p.setRenderHint(QtGui.QPainter.Antialiasing, True)
+
+        side = min(self.width(), self.height())
+        box = QtCore.QRectF((self.width() - side) * 0.5, (self.height() - side) * 0.5, side, side)
+
+        c = box.center()
+        p.translate(c)
+        p.rotate(self._angle)
+        p.translate(-c)
+
+        img = QtGui.QImage(
+            int(box.width()), int(box.height()), QtGui.QImage.Format_ARGB32_Premultiplied
+        )
+        img.fill(0)
+        ip = QtGui.QPainter(img)
+        ip.setRenderHint(QtGui.QPainter.Antialiasing, True)
+        self._renderer.render(ip, QtCore.QRectF(0, 0, box.width(), box.height()))
+        ip.setCompositionMode(QtGui.QPainter.CompositionMode_SourceIn)
+        ip.fillRect(img.rect(), self._pick_fg())
+        ip.end()
+
+        # Blit tinted image
+        p.drawImage(box.topLeft(), img)
+
+
+def _srgb_luminance(c: QtGui.QColor) -> float:
+    """Relative luminance per WCAG (0..1)."""
+
+    def lin(u):
+        u = u / 255.0
+        return u / 12.92 if u <= 0.04045 else ((u + 0.055) / 1.055) ** 2.4
+
+    return 0.2126 * lin(c.red()) + 0.7152 * lin(c.green()) + 0.0722 * lin(c.blue())

--- a/addonmanager_package_details_controller.py
+++ b/addonmanager_package_details_controller.py
@@ -98,6 +98,8 @@ class PackageDetailsController(QtCore.QObject):
                 self.worker.requestInterruption()
                 self.worker.wait()
 
+        self.ui.button_bar.set_update_check_status(False)
+
         installed = self.addon.status() != Addon.Status.NOT_INSTALLED
         self.ui.set_installed(installed)
         if self.addon.metadata is not None:
@@ -135,6 +137,8 @@ class PackageDetailsController(QtCore.QObject):
             self.update_check_thread.started.connect(self.check_for_update_worker.do_work)
             self.check_for_update_worker.update_status.connect(self.display_repo_status)
             self.update_check_thread.start()
+            if self.update_check_thread.isRunning():
+                self.ui.button_bar.set_update_check_status(True)
 
         flags = WarningFlags()
         self.ui.set_warning_flags(flags)
@@ -241,3 +245,4 @@ class PackageDetailsController(QtCore.QObject):
     def display_repo_status(self, addon):
         self.update_status.emit(self.addon)
         self.show_addon(self.addon)
+        self.ui.button_bar.set_update_check_status(False)


### PR DESCRIPTION
Update checks happen automatically on startup (for most addons it is just part of the supplied metadata in the catalog, only custom addons need to be checked at their source). In rare circumstances something might happen to interrupt this: if that happened, automatically run an update check when the addon's detailed view is shown, and display a small spinner to indicate that is happening.