### PR TITLE
Clean up license norming diagnostic output

### DIFF
--- a/addonmanager_macro_parser.py
+++ b/addonmanager_macro_parser.py
@@ -207,7 +207,17 @@ class MacroParser:
     def _cleanup_license(self):
         if get_license_manager is not None:
             lm = get_license_manager()
-            self.parse_results["license"] = lm.normalize(self.parse_results["license"])
+            normed_license = lm.normalize(self.parse_results["license"])
+            if not normed_license:
+                fci.Console.PrintWarning(
+                    f"Failed to normalize license {self.parse_results['license']} for macro '{self.name}'\n"
+                )
+                return
+            elif normed_license != self.parse_results["license"]:
+                fci.Console.PrintMessage(
+                    f"Normalized license {self.parse_results['license']} for macro '{self.name}' to {normed_license}\n"
+                )
+                self.parse_results["license"] = normed_license
 
     def _apply_special_handling(self, key: str, line: str):
         # Macro authors are supposed to be providing strings here, but in some

--- a/addonmanager_metadata.py
+++ b/addonmanager_metadata.py
@@ -304,7 +304,7 @@ class MetadataReader:
             metadata.__dict__[tag].append(MetadataReader._parse_contact(child))
         elif tag == "license":
             # List of licenses
-            metadata.license.append(MetadataReader._parse_license(child))
+            metadata.license.append(MetadataReader._parse_license(child, metadata.name))
         elif tag == "url":
             # List of urls
             metadata.url.append(MetadataReader._parse_url(child))
@@ -320,11 +320,18 @@ class MetadataReader:
         return Contact(name=child.text, email=email)
 
     @staticmethod
-    def _parse_license(child: ET.Element) -> License:
+    def _parse_license(child: ET.Element, name: str) -> License:
         file = child.attrib["file"] if "file" in child.attrib else ""
         license_id = child.text
         lm = get_license_manager()
-        license_id = lm.normalize(license_id)
+        normed_license = lm.normalize(license_id)
+        if not normed_license:
+            print(f"Unrecognized SPDX license ID specified for addon '{name}': '{license_id}'")
+        elif normed_license != license_id:
+            print(
+                f"Unrecognized license string '{license_id}' normalized to SPDX license ID '{normed_license}' for addon '{name}'"
+            )
+            license_id = normed_license
         return License(name=license_id, file=file)
 
     @staticmethod


### PR DESCRIPTION
It was impossible to tell which addons had unrecognized or un-normalizable licenses before: this modifies the diagnostic output so it's clear which addons have non-SPDX license identifiers.