### PR TITLE
Clean up shutdown with running get processes

### DIFF
--- a/NetworkManager.py
+++ b/NetworkManager.py
@@ -413,8 +413,10 @@ class NetworkManager(QtCore.QObject):
             p = self.blocking_get(url, timeout_ms)
             if p is not None or attempt >= max_attempts:
                 return p
+            if QtCore.QThread.currentThread().isInterruptionRequested():
+                return None
             fci.Console.PrintWarning(
-                f"Failed to get {url}, retrying in {delay_ms}ms... (attempt {attempt} of {max_attempts})"
+                f"Failed to get {url}, retrying in {delay_ms}ms... (attempt {attempt} of {max_attempts})\n"
             )
             time.sleep(delay_ms / 1000)
 

--- a/addonmanager_workers_startup.py
+++ b/addonmanager_workers_startup.py
@@ -169,6 +169,8 @@ class CreateAddonListWorker(QtCore.QThread):
         p = NetworkManager.AM_NETWORK_MANAGER.blocking_get_with_retries(
             url, cls.ATTEMPT_TIMEOUT_MS, cls.MAX_ATTEMPTS, cls.RETRY_DELAY_MS
         )
+        if QtCore.QThread.currentThread().isInterruptionRequested():
+            return ""
         if not p:
             raise RuntimeError(
                 f"Failed to download cache from {url} after {cls.MAX_ATTEMPTS} attempts"
@@ -210,6 +212,8 @@ class CreateAddonListWorker(QtCore.QThread):
         p = NetworkManager.AM_NETWORK_MANAGER.blocking_get_with_retries(
             hash_url, cls.ATTEMPT_TIMEOUT_MS, cls.MAX_ATTEMPTS, cls.RETRY_DELAY_MS
         )
+        if QtCore.QThread.currentThread().isInterruptionRequested():
+            return False
         if not p:
             raise RuntimeError(
                 f"Failed to download cache hash from remote server {hash_url} after {cls.MAX_ATTEMPTS} attempts"
@@ -557,6 +561,8 @@ class GetBasicAddonStatsWorker(QtCore.QThread):
         fetch_result = NetworkManager.AM_NETWORK_MANAGER.blocking_get_with_retries(
             self.url, self.ATTEMPT_TIMEOUT_MS, self.MAX_ATTEMPTS, self.RETRY_DELAY_MS
         )
+        if QtCore.QThread.currentThread().isInterruptionRequested():
+            return
         if fetch_result is None:
             fci.Console.PrintError(
                 translate(
@@ -597,6 +603,8 @@ class GetAddonScoreWorker(QtCore.QThread):
             fetch_result = NetworkManager.AM_NETWORK_MANAGER.blocking_get_with_retries(
                 self.url, self.ATTEMPT_TIMEOUT_MS, self.MAX_ATTEMPTS, self.RETRY_DELAY_MS
             )
+            if QtCore.QThread.currentThread().isInterruptionRequested():
+                return
             if fetch_result is None:
                 fci.Console.PrintError(
                     translate(


### PR DESCRIPTION
If a thread interruption was requested, don't report it as an error when the network accesses are killed and don't return any data. Also don't retry the attempt, regardless of retry count.