### PR TITLE
Set up the development branch version and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FreeCAD Addon Manager
 
+**NOTE: This is the "dev" (development) branch of the Addon Manager. Most users should use "main" instead.**
+
 Install and update third-party addons to FreeCAD, including Workbenches, Macros, Preference Packs, and more. FreeCAD
 ships with a point-in-time snapshot of this Addon: by the time you install FreeCAD it is possible that version of the
 Addon Manager is no longer the most recent version. Install *this* addon to update the internal Addon Manager to the

--- a/package.xml
+++ b/package.xml
@@ -3,18 +3,18 @@
  to the newest Addon Manager. This can be changed when FreeCAD v1.0 is no longer supported. -->
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
     <name>Addon Manager</name>
-    <description>Tool to install workbenches, macros, themes, etc.</description>
+    <description>Development branch of a tool to install workbenches, macros, themes, etc.</description>
     <icon>Resources/icons/addon_manager.svg</icon>
-    <version>2025.08.16</version>
-    <date>2025-08-16</date>
+    <version>2025.08.17dev</version>
+    <date>2025-08-17</date>
     <maintainer email='chennes@freecad.org'>Chris Hennes</maintainer>
     <author email = 'yorik@uncreated.net'>Yorik van Havre</author>
     <author>Jonathan Wiedemann</author>
     <author>Kurt Kremitzki</author>
     <license file="LICENSE">LGPL-2.1-or-later</license>
-    <url type='repository' branch='main'>https://github.com/FreeCAD/AddonManager</url>
+    <url type='repository' branch='dev'>https://github.com/FreeCAD/AddonManager</url>
     <url type='bugtracker'>https://github.com/FreeCAD/AddonManager/issues</url>
-    <url type='readme'>https://github.com/FreeCAD/AddonManager/blob/main/README.md</url>
+    <url type='readme'>https://github.com/FreeCAD/AddonManager/blob/dev/README.md</url>
 
     <content>
         <workbench>


### PR DESCRIPTION
Modify the version number to include "dev", and ensure the README and description make it clear that this is the Development branch.