### PR TITLE
Create sync_dev_to_main.yml

### DIFF
--- a/.github/workflows/sync_dev_to_main.yml
+++ b/.github/workflows/sync_dev_to_main.yml
@@ -1,0 +1,49 @@
+name: Take a PR from dev to main
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+    branches: [dev]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Create release pull request
+    runs-on: ubuntu-latest
+
+    # Run the action if a PR is merged with "release to main" label
+    # OR
+    # when already merged PR is labeled with "release to main" label
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && startsWith(github.event.label.name, 'release to ')
+        )
+      )
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Create backport pull requests
+        uses: korthout/backport-action@ca4972adce8039ff995e618f5fc02d1b7961f27a # v3.3.0
+        with:
+          # Inputs documented here: https://github.com/korthout/backport-action?tab=readme-ov-file#inputs
+          github_token: ${{ github.token }}
+          github_workspace: ${{ github.workspace }}
+
+          # permit PRs with merge commits to be backported
+          merge_commits: 'skip'
+
+          # copy labels to backport to identify affected systems and priorities
+          copy_labels_pattern: '.*'
+
+          # Regex pattern to match github labels
+          # The capture group catches the target branch
+          # i.e. label "release to main" will create PR against main
+          label_pattern: ^release to ([^ ]+)$


### PR DESCRIPTION
Modeled after the action we use on FreeCAD, this is an action that will allow a ,maintainer to add the "release to main" tag to a PR that was merged to the dev branch, and have a PR automatically created for moving it to main.