### PR TITLE
Switch CI runs to the dev branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "dev" ]
   schedule:
     - cron: '32 11 * * 4'
 

--- a/.github/workflows/qt5-tests.yml
+++ b/.github/workflows/qt5-tests.yml
@@ -2,9 +2,9 @@ name: Run Qt5 tests
 
 on:
   push:
-    branches: [main]
+    branches: [dev, main]
   pull_request:
-    branches: [main]
+    branches: [dev, main]
 
 permissions:
   contents: read

--- a/.github/workflows/qt6-tests.yml
+++ b/.github/workflows/qt6-tests.yml
@@ -2,9 +2,9 @@ name: Run Qt6 tests
 
 on:
   push:
-    branches: [main]
+    branches: [dev, main]
   pull_request:
-    branches: [main]
+    branches: [dev, main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Now that the dev branch is listed as the primary here, move over the CI runs to happen on that branch (the tests will run on both, and CodeQL will only run on dev).