### PR TITLE
Add ability to disable QNAM cache for requests

### DIFF
--- a/addonmanager_connection_checker.py
+++ b/addonmanager_connection_checker.py
@@ -37,6 +37,7 @@ class ConnectionCheckerGUI(QtCore.QObject):
     starts to take too long, and an error message if the network cannot be accessed."""
 
     connection_available = QtCore.Signal()
+    no_connection = QtCore.Signal()
     check_complete = QtCore.Signal()
 
     def __init__(self):
@@ -87,12 +88,13 @@ class ConnectionCheckerGUI(QtCore.QObject):
         # This must run on the main GUI thread
         if hasattr(self, "connection_check_message") and self.connection_check_message:
             self.connection_check_message.close()
+        self.no_connection.emit()
         MessageDialog.show_modal(
             MessageDialog.DialogType.ERROR,
             "AddonManager_ConnectionFailedDialog",
             translate("AddonsInstaller", "Connection failed"),
             message,
-            QtWidgets.QMessageBox.OK,
+            QtWidgets.QMessageBox.Ok,
         )
         self._disconnect_signals()
         self.check_complete.emit()

--- a/addonmanager_workers_utility.py
+++ b/addonmanager_workers_utility.py
@@ -63,7 +63,7 @@ class ConnectionChecker(QtCore.QThread):
         self.done = False
         NetworkManager.AM_NETWORK_MANAGER.completed.connect(self.connection_data_received)
         self.request_id = NetworkManager.AM_NETWORK_MANAGER.submit_unmonitored_get(
-            url, timeout_ms=30000
+            url, timeout_ms=30000, disable_cache=True
         )
         while not self.done:
             if QtCore.QThread.currentThread().isInterruptionRequested():


### PR DESCRIPTION
The data packet being queried for in the connection check was extremely small, and the `QNetworkAccessManager` was caching it. This caused it to look like we had a live network connection, even though there was none. Coupled with the bug resulting from the lack of Mod directory and the startup behavior was very strange. Fixes #198.