### PR TITLE
Fix error installing addons as dependencies

### DIFF
--- a/AddonManager.py
+++ b/AddonManager.py
@@ -644,7 +644,7 @@ class CommandAddonManager(QtCore.QObject):
                 proceed = False
                 all_deps = set()
                 all_deps.update(deps.wbs)
-                all_deps.update(deps.external_addons)
+                all_deps.update([addon.name for addon in deps.external_addons])
                 all_deps.update(deps.python_requires)
                 for dep in all_deps:
                     if dep not in ignored_deps:
@@ -669,7 +669,7 @@ class CommandAddonManager(QtCore.QObject):
         old_deps = set(old_deps_string.split(";") if old_deps_string else [])
         deps = self.check_missing_dependencies_worker.missing_dependencies
         new_deps = old_deps.union(deps.wbs)
-        new_deps = new_deps.union(deps.external_addons)
+        new_deps = new_deps.union([addon.name for addon in deps.external_addons])
         new_deps = new_deps.union(deps.python_requires)
         new_deps_string = ";".join(new_deps)
         fci.Preferences().set("ignored_missing_deps", new_deps_string)

--- a/addonmanager_installer_gui.py
+++ b/addonmanager_installer_gui.py
@@ -613,7 +613,7 @@ class AddonDependencyInstallerGUI(QtCore.QObject):
         """Ask the user how they want to handle dependencies, do that, then install."""
 
         for addon in self.deps.external_addons:
-            self.dependency_dialog.listWidgetAddons.addItem(addon)
+            self.dependency_dialog.listWidgetAddons.addItem(addon.display_name)
         for mod in self.deps.python_requires:
             self.dependency_dialog.listWidgetPythonRequired.addItem(mod)
         for mod in self.deps.python_optional:
@@ -674,17 +674,8 @@ class AddonDependencyInstallerGUI(QtCore.QObject):
         self.deps.python_optional = good_packages
 
     def _dependency_dialog_yes_clicked(self) -> None:
-        # Get the lists out of the dialog:
-        addons = []
-        for row in range(self.dependency_dialog.listWidgetAddons.count()):
-            item = self.dependency_dialog.listWidgetAddons.item(row)
-            addons.append(item.text())
-
-        python_requires = []
-        for row in range(self.dependency_dialog.listWidgetPythonRequired.count()):
-            item = self.dependency_dialog.listWidgetPythonRequired.item(row)
-            python_requires.append(item.text())
-
+        addons = self.deps.external_addons
+        python_requires = self.deps.python_requires
         python_optional = []
         for row in range(self.dependency_dialog.listWidgetPythonOptional.count()):
             item = self.dependency_dialog.listWidgetPythonOptional.item(row)

--- a/addonmanager_update_all_gui.py
+++ b/addonmanager_update_all_gui.py
@@ -25,7 +25,7 @@
 import threading
 from enum import IntEnum, auto
 import os
-from typing import List
+from typing import List, Set
 
 import NetworkManager
 from PySideWrapper import QtCore, QtWidgets
@@ -264,7 +264,9 @@ class UpdateAllGUI(QtCore.QObject):
             if required_wbs:
                 fci.Console.PrintMessage(f"  Required Workbenches: {required_wbs}\n")
             if required_addons:
-                fci.Console.PrintMessage(f"  Required Addons: {required_addons}\n")
+                fci.Console.PrintMessage(
+                    f"  Required Addons: {','.join([x.display_name for x in required_addons])}\n"
+                )
             if required_python_modules:
                 fci.Console.PrintMessage(f"  Required Python Modules: {required_python_modules}\n")
             if optional_python_modules:
@@ -282,17 +284,17 @@ class UpdateAllGUI(QtCore.QObject):
 
     def handle_missing_dependencies(
         self,
-        addons,
-        required_wbs,
-        required_addons,
-        required_python_modules,
-        optional_python_modules,
+        addons: List[Addon],
+        required_wbs: Set[str],
+        required_addons: Set[Addon],
+        required_python_modules: Set[str],
+        optional_python_modules: Set[str],
     ):
         missing_dependencies = MissingDependencies()
-        missing_dependencies.wbs = required_wbs
-        missing_dependencies.external_addons = required_addons
-        missing_dependencies.python_requires = required_python_modules
-        missing_dependencies.python_optional = optional_python_modules
+        missing_dependencies.wbs = list(required_wbs)
+        missing_dependencies.external_addons = list(required_addons)
+        missing_dependencies.python_requires = list(required_python_modules)
+        missing_dependencies.python_optional = list(optional_python_modules)
         self.dependency_installer = AddonDependencyInstallerGUI(addons, missing_dependencies)
         self.dependency_installer.cancel.connect(self.cancel)
         self.dependency_installer.proceed.connect(self.check_for_git_migration)

--- a/addonmanager_workers_startup.py
+++ b/addonmanager_workers_startup.py
@@ -674,9 +674,7 @@ class CheckForMissingDependenciesWorker(QtCore.QThread):
             if deps.wbs:
                 details += f"{addon.display_name} is missing workbenches {', '.join(deps.wbs)}\n"
             if deps.external_addons:
-                details += (
-                    f"{addon.display_name} is missing addons {', '.join(deps.external_addons)}\n"
-                )
+                details += f"{addon.display_name} is missing addons {', '.join([x.display_name for x in deps.external_addons])}\n"
             if deps.python_requires:
                 details += f"{addon.display_name} is missing python packages {', '.join(deps.python_requires)}\n"
             self.missing_dependencies.join(deps)


### PR DESCRIPTION
Due to missing type-hinting, there were some places in the code attempting to treat a list of addons as a list of strings. This corrects the missing type hints, and fixes the errant code paths.