### PR TITLE
Fix proxy settings, migrate format, improve UI

### DIFF
--- a/AddonManagerOptions.py
+++ b/AddonManagerOptions.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
-# *   Copyright (c) 2022 FreeCAD Project Association                        *
+# *   Copyright (c) 2022-2025 The FreeCAD project association AISBL         *
 # *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
@@ -24,19 +24,93 @@
 """Contains the Addon Manager's preferences dialog management class"""
 
 import os
+from enum import StrEnum, IntEnum
+from typing import Tuple
 
 import addonmanager_freecad_interface as fci
+from addonmanager_preferences_migrations import migrate_proxy_settings_2025
+from NetworkManager import ForceReinitializeNetworkManager
 
-
-from PySideWrapper import QtCore, QtGui, QtWidgets
+from PySideWrapper import QtCore, QtGui, QtWidgets, QtNetwork
 
 translate = fci.translate
 
 # pylint: disable=too-few-public-methods
 
 
+def test_proxy_connection(
+    proxy: QtNetwork.QNetworkProxy | QtNetwork.QNetworkProxy.ProxyType,
+) -> Tuple[bool, str]:
+
+    nam = QtNetwork.QNetworkAccessManager()
+    nam.setProxy(proxy)
+    req = QtNetwork.QNetworkRequest(QtCore.QUrl("https://addons.freecad.org/status"))
+    req.setAttribute(QtNetwork.QNetworkRequest.Http2AllowedAttribute, False)
+    reply = nam.get(req)
+    loop = QtCore.QEventLoop()
+    timer = QtCore.QTimer()
+    timer.setSingleShot(True)
+    timer.timeout.connect(loop.quit)
+    reply.finished.connect(loop.quit)
+    timer.start(3000)
+    if hasattr(loop, "exec"):
+        loop.exec()
+    else:
+        loop.exec_()  # Qt5
+    if timer.isActive():
+        timer.stop()
+    else:
+        reply.abort()
+        reply.deleteLater()
+        nam.deleteLater()
+        return False, translate("AddonsInstaller", "Proxy test timed out: no connection made.")
+
+    if reply.error() != QtNetwork.QNetworkReply.NoError:
+        msg = f"QtNetwork error: {reply.error()} - {reply.errorString()}"
+        reply.deleteLater()
+        nam.deleteLater()
+        return (
+            False,
+            translate("AddonsInstaller", "Proxy test returned an error: no connection made.\n")
+            + msg,
+        )
+
+    status = reply.attribute(QtNetwork.QNetworkRequest.HttpStatusCodeAttribute)
+    status = int(status) if status is not None else None
+    reason = reply.attribute(QtNetwork.QNetworkRequest.HttpReasonPhraseAttribute)
+    reason = (
+        bytes(reason).decode("utf-8") if isinstance(reason, QtCore.QByteArray) else (reason or "")
+    )
+
+    reply.deleteLater()
+    nam.deleteLater()
+
+    # Success criteria: 2xx or 3xx typically indicates the proxy path worked.
+    if status is not None and 200 <= status < 400:
+        return True, translate("AddonsInstaller", "Proxy test succeeded, connection established.")
+    if status == 407:
+        return False, translate(
+            "AddonsInstaller",
+            "Proxy requires authentication. The Addon Manager does not support this.",
+        )
+    return False, translate("AddonsInstaller", "Proxy connection failed with code {}: {}.").format(
+        status, reason
+    )
+
+
 class AddonManagerOptions:
     """A class containing a form element that is inserted as a FreeCAD preference page."""
+
+    class ProxyType(StrEnum):
+        none = "none"
+        system = "system"
+        custom = "custom"
+
+    class ProxyTestStatus(IntEnum):
+        untested = 0
+        testing = 1
+        success = 2
+        failure = 3
 
     def __init__(self, _=None):
         self.form = fci.loadUi(os.path.join(os.path.dirname(__file__), "AddonManagerOptions.ui"))
@@ -63,12 +137,159 @@ class AddonManagerOptions:
         self.form.removeCustomRepositoryButton.clicked.connect(self._remove_custom_repo_clicked)
         self.form.customRepositoriesTableView.doubleClicked.connect(self._row_double_clicked)
 
+        self.form.proxyGroupBox.toggled.connect(self._proxy_state_changed)
+        self.form.systemProxyButton.clicked.connect(self._proxy_type_changed)
+        self.form.customProxyButton.clicked.connect(self._proxy_type_changed)
+        self.form.proxyTestButton.clicked.connect(self._test_proxy)
+        self.form.proxyTestButton.setIcon(
+            QtGui.QIcon.fromTheme(
+                "view-refresh", QtGui.QIcon(os.path.join(icon_path, "view-refresh"))
+            )
+        )
+        self.form.proxyHostLineEdit.textChanged.connect(self._proxy_changed)
+        self.form.proxyPortLineEdit.textChanged.connect(self._proxy_changed)
+        self._set_proxy_test_button_state(AddonManagerOptions.ProxyTestStatus.untested)
+
+        int_validator = QtGui.QIntValidator(1, 65535)  # Valid range for port numbers
+        self.form.proxyPortLineEdit.setValidator(int_validator)
+
+        # Not a 100% valid hostname, but good enough for our purposes (for now)
+        hostname_regex = QtCore.QRegularExpression(
+            r"^[A-Za-z0-9]+(?:[-A-Za-z0-9]*[A-Za-z0-9])?(?:\.[A-Za-z0-9]+(?:[-A-Za-z0-9]*[A-Za-z0-9])?)*$"
+        )
+        self.form.proxyHostLineEdit.setValidator(QtGui.QRegularExpressionValidator(hostname_regex))
+
+        self.form.proxyStatusTestGroupBox.setVisible(False)
+
+        migrate_proxy_settings_2025()
+
+    def reconfigure_proxy_ui(self, proxy_type: ProxyType):
+        if proxy_type == AddonManagerOptions.ProxyType.none:
+            self.form.proxyGroupBox.setChecked(False)
+            self.form.proxyHostLineEdit.setPlaceholderText(translate("AddonsInstaller", "No proxy"))
+            self.form.proxyPortLineEdit.setPlaceholderText(translate("AddonsInstaller", "n/a"))
+        else:
+            self.form.proxyGroupBox.setChecked(True)
+            self.form.proxyHostLineEdit.setPlaceholderText(
+                translate("AddonsInstaller", "proxy.example.com")
+            )
+            self.form.proxyPortLineEdit.setPlaceholderText("8080")
+            if proxy_type == AddonManagerOptions.ProxyType.system:
+                self.form.systemProxyButton.setChecked(True)
+                self.form.proxyHostLineEdit.setEnabled(False)
+                self.form.proxyPortLineEdit.setEnabled(False)
+            else:
+                self.form.customProxyButton.setChecked(True)
+                self.form.proxyHostLineEdit.setEnabled(True)
+                self.form.proxyPortLineEdit.setEnabled(True)
+
+    def fill_proxy_host_settings_from_preferences(self):
+        proxy_type = fci.Preferences().get("proxy_type")
+        if proxy_type == AddonManagerOptions.ProxyType.none:
+            self.form.proxyHostLineEdit.setText(translate("AddonsInstaller", "No proxy"))
+            self.form.proxyPortLineEdit.setText("8080")
+        elif proxy_type == AddonManagerOptions.ProxyType.system:
+            self.fill_proxy_with_system_settings()
+        else:
+            self.form.proxyHostLineEdit.setText(fci.Preferences().get("proxy_host"))
+            self.form.proxyPortLineEdit.setText(str(fci.Preferences().get("proxy_port")))
+
+    def _custom_activated(self):
+        self.form.proxyHostLineEdit.setText(fci.Preferences().get("proxy_host"))
+        self.form.proxyPortLineEdit.setText(str(fci.Preferences().get("proxy_port")))
+
+    def fill_proxy_with_system_settings(self):
+        query = QtNetwork.QNetworkProxyQuery(QtCore.QUrl("https://addons.freecad.org/status"))
+        proxy = QtNetwork.QNetworkProxyFactory.systemProxyForQuery(query)
+        if proxy and proxy[0] and proxy[0].hostName() and proxy[0].port() > 0:
+            self.form.proxyHostLineEdit.setText(proxy[0].hostName())
+            self.form.proxyPortLineEdit.setText(str(proxy[0].port()))
+        else:
+            self.form.proxyHostLineEdit.setText(translate("AddonsInstaller", "System has no proxy"))
+            self.form.proxyPortLineEdit.setText("8080")
+
+    def _proxy_type_changed(self):
+        """Callback: when the proxy type is changed, update the UI accordingly"""
+        proxy_type = self._proxy_type_from_ui()
+        self.reconfigure_proxy_ui(proxy_type)
+        self.fill_proxy_host_settings_from_preferences()
+        self._proxy_changed()
+        if proxy_type == AddonManagerOptions.ProxyType.custom:
+            self._custom_activated()
+
+    def _proxy_state_changed(self):
+        """Callback: when the proxy state is changed, update the UI accordingly"""
+        proxy_type = self._proxy_type_from_ui()
+        self.reconfigure_proxy_ui(proxy_type)
+        self._proxy_changed()
+        if proxy_type == AddonManagerOptions.ProxyType.none:
+            self.form.proxyHostLineEdit.setText(translate("AddonsInstaller", "No proxy"))
+        elif proxy_type == AddonManagerOptions.ProxyType.system:
+            self.fill_proxy_with_system_settings()
+        else:
+            self.fill_proxy_host_settings_from_preferences()
+
+    def _proxy_changed(self):
+        self._set_proxy_test_button_state(AddonManagerOptions.ProxyTestStatus.untested)
+
+    def _test_proxy(self):
+        """Callback: when the test proxy button is clicked, test the proxy settings"""
+        self._set_proxy_test_button_state(AddonManagerOptions.ProxyTestStatus.testing)
+        self.form.proxyStatusTestGroupBox.setVisible(True)
+        self.form.proxyStatusTestOutputLabel.setText(
+            translate("AddonsInstaller", "Testing proxy connection…")
+        )
+        proxy_type = self._proxy_type_from_ui()
+        if proxy_type == AddonManagerOptions.ProxyType.none:
+            proxy = QtNetwork.QNetworkProxy.NoProxy
+        else:
+            if proxy_type == AddonManagerOptions.ProxyType.system:
+                query = QtNetwork.QNetworkProxyQuery(
+                    QtCore.QUrl("https://addons.freecad.org/status")
+                )
+                proxies = QtNetwork.QNetworkProxyFactory.systemProxyForQuery(query)
+                if proxies and proxies[0] and proxies[0].hostName() and proxies[0].port() > 0:
+                    proxy = proxies[0]
+                else:
+                    proxy = QtNetwork.QNetworkProxy.NoProxy
+            else:
+                scheme = QtNetwork.QNetworkProxy.HttpProxy
+                host = self.form.proxyHostLineEdit.text()
+                port = int(self.form.proxyPortLineEdit.text())
+                proxy = QtNetwork.QNetworkProxy(scheme, host, port)
+
+        status, message = test_proxy_connection(proxy)
+        self.form.proxyStatusTestOutputLabel.setText(message)
+        self._set_proxy_test_button_state(
+            AddonManagerOptions.ProxyTestStatus.success
+            if status
+            else AddonManagerOptions.ProxyTestStatus.failure
+        )
+
+    def _set_proxy_test_button_state(self, state: ProxyTestStatus):
+        icon_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "Resources", "icons")
+        icon = QtGui.QIcon.fromTheme(
+            "view-refresh", QtGui.QIcon(os.path.join(icon_path, "view-refresh"))
+        )
+        if state == AddonManagerOptions.ProxyTestStatus.success:
+            icon = QtGui.QIcon.fromTheme("ok", QtGui.QIcon(os.path.join(icon_path, "regex_ok.svg")))
+        elif state == AddonManagerOptions.ProxyTestStatus.failure:
+            icon = QtGui.QIcon.fromTheme(
+                "cancel", QtGui.QIcon(os.path.join(icon_path, "regex_bad.svg"))
+            )
+        if state == AddonManagerOptions.ProxyTestStatus.testing:
+            self.form.proxyTestButton.setEnabled(False)
+        else:
+            self.form.proxyTestButton.setEnabled(True)
+        self.form.proxyTestButton.setIcon(icon)
+
     def saveSettings(self):
         """Required function: called by the preferences dialog when Apply or Save is clicked,
         saves out the preference data by reading it from the widgets."""
         for widget in self.form.children():
             self.recursive_widget_saver(widget)
         self.table_model.save_model()
+        self.save_proxy_settings()
 
     def recursive_widget_saver(self, widget):
         """Writes out the data for this widget and all of its children, recursively."""
@@ -105,12 +326,41 @@ class AddonManagerOptions:
             for child in widget.children():
                 self.recursive_widget_saver(child)
 
+    def _proxy_type_from_ui(self) -> ProxyType:
+        if self.form.proxyGroupBox.isChecked():
+            if self.form.systemProxyButton.isChecked():
+                return AddonManagerOptions.ProxyType.system
+            return AddonManagerOptions.ProxyType.custom
+        return AddonManagerOptions.ProxyType.none
+
+    def save_proxy_settings(self):
+        """Save the proxy settings -- the line edits are taken care of by the widgets, but the
+        check state of the group box, and the selection state of the two buttons, must be manually
+        determined and stored."""
+        proxy_type = str(self._proxy_type_from_ui())
+        host = self.form.proxyHostLineEdit.text() if proxy_type == "custom" else ""
+        port = int(self.form.proxyPortLineEdit.text()) if proxy_type == "custom" else 8080
+
+        if (
+            fci.Preferences().get("proxy_type") != proxy_type
+            or fci.Preferences().get("proxy_host") != host
+            or fci.Preferences().get("proxy_port") != port
+        ):
+            fci.Preferences().set("proxy_type", proxy_type)
+            fci.Preferences().set("proxy_host", self.form.proxyHostLineEdit.text())
+            fci.Preferences().set("proxy_port", int(self.form.proxyPortLineEdit.text()))
+            ForceReinitializeNetworkManager()
+
     def loadSettings(self):
         """Required function: called by the preferences dialog when it is launched,
         loads the preference data and assigns it to the widgets."""
         for widget in self.form.children():
             self.recursive_widget_loader(widget)
         self.table_model.load_model()
+
+        proxy_type = fci.Preferences().get("proxy_type")
+        self.reconfigure_proxy_ui(proxy_type)
+        self.fill_proxy_host_settings_from_preferences()
 
     def recursive_widget_loader(self, widget):
         """Loads the data for this widget and all of its children, recursively."""
@@ -183,6 +433,7 @@ class CustomRepoDataModel(QtCore.QAbstractTableModel):
         super().__init__()
         pref_access_string = "User parameter:BaseApp/Preferences/Addons"
         self.pref = fci.FreeCAD.ParamGet(pref_access_string)
+        self.model = []
         self.load_model()
 
     def load_model(self):
@@ -255,19 +506,25 @@ class CustomRepoDataModel(QtCore.QAbstractTableModel):
             )
         return None
 
-    def removeRows(self, row, count, parent):
+    def removeRows(
+        self, row: int, count: int, parent: QtCore.QModelIndex | QtCore.QPersistentModelIndex
+    ) -> bool:
         """Remove rows"""
         self.beginRemoveRows(parent, row, row + count - 1)
         for _ in range(count):
             self.model.pop(row)
         self.endRemoveRows()
+        return True
 
-    def insertRows(self, row, count, parent):
+    def insertRows(
+        self, row: int, count: int, parent: QtCore.QModelIndex | QtCore.QPersistentModelIndex
+    ) -> bool:
         """Insert blank rows"""
         self.beginInsertRows(parent, row, row + count - 1)
         for _ in range(count):
-            self.model.insert(["", ""])
+            self.model.insert(row, ["", ""])
         self.endInsertRows()
+        return True
 
     def appendData(self, url, branch):
         """Append this url and branch to the end of the list"""

--- a/AddonManagerOptions.py
+++ b/AddonManagerOptions.py
@@ -48,9 +48,10 @@ def is_ip(host: str) -> bool:
         return False
 
 
-DOMAIN_REGEX = re.compile(
-    r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)" r"(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$"
-)
+# Simple regex for valid domain names. Not exhaustive, but hopefully good enough.
+# * Each label starts/ends with alphanumeric, can contain hyphens.
+# * TLD must be at least 2 letters.
+DOMAIN_REGEX = re.compile(r"^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,}$")
 
 
 def is_domain(host: str) -> bool:

--- a/AddonManagerOptions.py
+++ b/AddonManagerOptions.py
@@ -44,7 +44,8 @@ def test_proxy_connection(
 
     nam = QtNetwork.QNetworkAccessManager()
     nam.setProxy(proxy)
-    req = QtNetwork.QNetworkRequest(QtCore.QUrl("https://addons.freecad.org/status"))
+    url = fci.Preferences().get("status_test_url")
+    req = QtNetwork.QNetworkRequest(QtCore.QUrl(url))
     req.setAttribute(QtNetwork.QNetworkRequest.Http2AllowedAttribute, False)
     reply = nam.get(req)
     loop = QtCore.QEventLoop()
@@ -199,7 +200,8 @@ class AddonManagerOptions:
         self.form.proxyPortLineEdit.setText(str(fci.Preferences().get("proxy_port")))
 
     def fill_proxy_with_system_settings(self):
-        query = QtNetwork.QNetworkProxyQuery(QtCore.QUrl("https://addons.freecad.org/status"))
+        url = fci.Preferences().get("status_test_url")
+        query = QtNetwork.QNetworkProxyQuery(QtCore.QUrl(url))
         proxy = QtNetwork.QNetworkProxyFactory.systemProxyForQuery(query)
         if proxy and proxy[0] and proxy[0].hostName() and proxy[0].port() > 0:
             self.form.proxyHostLineEdit.setText(proxy[0].hostName())
@@ -244,9 +246,8 @@ class AddonManagerOptions:
             proxy = QtNetwork.QNetworkProxy.NoProxy
         else:
             if proxy_type == AddonManagerOptions.ProxyType.system:
-                query = QtNetwork.QNetworkProxyQuery(
-                    QtCore.QUrl("https://addons.freecad.org/status")
-                )
+                url = fci.Preferences().get("status_test_url")
+                query = QtNetwork.QNetworkProxyQuery(QtCore.QUrl(url))
                 proxies = QtNetwork.QNetworkProxyFactory.systemProxyForQuery(query)
                 if proxies and proxies[0] and proxies[0].hostName() and proxies[0].port() > 0:
                     proxy = proxies[0]

--- a/AddonManagerOptions.ui
+++ b/AddonManagerOptions.ui
@@ -78,7 +78,6 @@
     <widget class="QLabel" name="label">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -93,10 +92,10 @@
       <bool>true</bool>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
+      <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
      </property>
      <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
+      <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
      </property>
      <property name="sortingEnabled">
       <bool>false</bool>
@@ -108,7 +107,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -154,19 +153,13 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QHBoxLayout" name="proxyMainButtonLayout">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
-         <widget class="QPushButton" name="systemProxyButton">
+         <widget class="QRadioButton" name="systemProxyButton">
           <property name="toolTip">
            <string>Use the system's proxy settings</string>
           </property>
           <property name="text">
            <string>System</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -174,29 +167,33 @@
           <property name="autoExclusive">
            <bool>true</bool>
           </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="customProxyButton">
+         <widget class="QRadioButton" name="customProxyButton">
           <property name="toolTip">
            <string>Use custom proxy settings</string>
           </property>
           <property name="text">
            <string>Custom</string>
           </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
           <property name="autoExclusive">
            <bool>true</bool>
           </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
          </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </item>
@@ -209,35 +206,38 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="proxyPortLabel">
-          <property name="text">
-           <string>Port</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLineEdit" name="proxyHostLineEdit"/>
-        </item>
-        <item row="1" column="1">
+        <item row="1" column="2">
          <widget class="QLabel" name="proxyColonSeparatorLabel">
           <property name="text">
            <string>:</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
+        <item row="1" column="3">
          <widget class="QLineEdit" name="proxyPortLineEdit"/>
         </item>
-        <item row="1" column="3">
-         <widget class="QToolButton" name="proxyTestButton">
+        <item row="0" column="3">
+         <widget class="QLabel" name="proxyPortLabel">
+          <property name="text">
+           <string>Port</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="proxyHostInvalidIcon"/>
+        </item>
+        <item row="1" column="4">
+         <widget class="QPushButton" name="proxyTestButton">
           <property name="toolTip">
            <string>Test these proxy settings</string>
           </property>
           <property name="text">
-           <string>...</string>
+           <string>Test Connection</string>
           </property>
          </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLineEdit" name="proxyHostLineEdit"/>
         </item>
        </layout>
       </item>
@@ -250,7 +250,7 @@
          <item>
           <widget class="QLabel" name="proxyStatusTestOutputLabel">
            <property name="text">
-            <string></string>
+            <string/>
            </property>
           </widget>
          </item>
@@ -293,7 +293,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -317,6 +317,21 @@
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>guiprefcheckboxhideunlicensed</tabstop>
+  <tabstop>guiprefcheckboxhidenonfsf</tabstop>
+  <tabstop>guiprefcheckboxnonosi</tabstop>
+  <tabstop>customRepositoriesTableView</tabstop>
+  <tabstop>addCustomRepositoryButton</tabstop>
+  <tabstop>removeCustomRepositoryButton</tabstop>
+  <tabstop>proxyGroupBox</tabstop>
+  <tabstop>systemProxyButton</tabstop>
+  <tabstop>customProxyButton</tabstop>
+  <tabstop>proxyHostLineEdit</tabstop>
+  <tabstop>proxyPortLineEdit</tabstop>
+  <tabstop>proxyTestButton</tabstop>
+  <tabstop>guipreflineeditscoresourceurl</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/AddonManagerOptions.ui
+++ b/AddonManagerOptions.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>757</width>
+    <width>569</width>
     <height>783</height>
    </rect>
   </property>
@@ -135,64 +135,126 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="proxyGroupBox">
+     <property name="toolTip">
+      <string>Use a proxy server for access to addon data</string>
+     </property>
      <property name="title">
-      <string>Proxy</string>
+      <string>Proxy addon manager traffic</string>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="Gui::PrefRadioButton" name="guiprefradiobuttonnoproxy">
-        <property name="text">
-         <string>No proxy</string>
+       <layout class="QHBoxLayout" name="proxyMainButtonLayout">
+        <property name="spacing">
+         <number>0</number>
         </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>NoProxyCheck</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Addons</cstring>
-        </property>
-       </widget>
+        <item>
+         <widget class="QPushButton" name="systemProxyButton">
+          <property name="toolTip">
+           <string>Use the system's proxy settings</string>
+          </property>
+          <property name="text">
+           <string>System</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="autoExclusive">
+           <bool>true</bool>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="customProxyButton">
+          <property name="toolTip">
+           <string>Use custom proxy settings</string>
+          </property>
+          <property name="text">
+           <string>Custom</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="autoExclusive">
+           <bool>true</bool>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="Gui::PrefRadioButton" name="guiprefradiobuttonsystemproxy">
-        <property name="text">
-         <string>User system proxy</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>SystemProxyCheck</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Addons</cstring>
-        </property>
-       </widget>
+       <layout class="QGridLayout" name="proxyHostSettingLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="proxyHostLabel">
+          <property name="text">
+           <string>Host</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLabel" name="proxyPortLabel">
+          <property name="text">
+           <string>Port</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLineEdit" name="proxyHostLineEdit"/>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="proxyColonSeparatorLabel">
+          <property name="text">
+           <string>:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLineEdit" name="proxyPortLineEdit"/>
+        </item>
+        <item row="1" column="3">
+         <widget class="QToolButton" name="proxyTestButton">
+          <property name="toolTip">
+           <string>Test these proxy settings</string>
+          </property>
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="Gui::PrefRadioButton" name="guiprefradiobuttonuserproxy">
-        <property name="text">
-         <string>User-defined proxy</string>
+       <widget class="QGroupBox" name="proxyStatusTestGroupBox">
+        <property name="title">
+         <string>Connection Test</string>
         </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>UserProxyCheck</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Addons</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefLineEdit" name="guipreflineedituserproxy">
-        <property name="prefEntry" stdset="0">
-         <cstring>ProxyUrl</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Addons</cstring>
-        </property>
+        <layout class="QHBoxLayout" name="proxyStatusTestLayout">
+         <item>
+          <widget class="QLabel" name="proxyStatusTestOutputLabel">
+           <property name="text">
+            <string></string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
@@ -247,11 +309,6 @@
   <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefRadioButton</class>
-   <extends>QRadioButton</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ SET(AddonManager_SRCS
     addonmanager_metadata.py
     addonmanager_package_details_controller.py
     addonmanager_preferences_defaults.json
+    addonmanager_preferences_migrations.py
     addonmanager_python_deps_gui.py
     addonmanager_python_deps.py
     addonmanager_readme_controller.py

--- a/addonmanager_preferences_defaults.json
+++ b/addonmanager_preferences_defaults.json
@@ -33,5 +33,9 @@
     "last_fetched_macro_cache_hash": "Cache never fetched, no hash available",
     "macro_cache_url": "https://addons.freecad.org/macro_cache.zip",
     "old_backup_handling": "ask",
+    "proxy_settings_migrated_2025": false,
+    "proxy_type": "system",
+    "proxy_host": "none",
+    "proxy_port": 8080,
     "readWarning2022": false
 }

--- a/addonmanager_preferences_defaults.json
+++ b/addonmanager_preferences_defaults.json
@@ -37,5 +37,6 @@
     "proxy_type": "system",
     "proxy_host": "none",
     "proxy_port": 8080,
-    "readWarning2022": false
+    "readWarning2022": false,
+    "status_test_url": "https://addons.freecad.org/status"
 }

--- a/addonmanager_preferences_migrations.py
+++ b/addonmanager_preferences_migrations.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2025 The FreeCAD project association AISBL              *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+from urllib.parse import urlparse
+
+import addonmanager_freecad_interface as fci
+
+
+def migrate_proxy_settings_2025():
+    """Migrate the proxy settings from the old format to the new format, established in 2025"""
+    if fci.Preferences().get("proxy_settings_migrated_2025"):
+        return
+    old_proxy_no = fci.Preferences().get("NoProxyCheck")
+    old_proxy_system = fci.Preferences().get("SystemProxyCheck")
+    old_proxy_user = fci.Preferences().get("UserProxyCheck")
+    old_proxy_url = fci.Preferences().get("ProxyUrl")
+
+    parsed_url = urlparse(old_proxy_url)
+
+    new_proxy_host = parsed_url.hostname if parsed_url.hostname else ""
+    new_proxy_port = int(parsed_url.port) if parsed_url.port else 8080
+
+    if old_proxy_system:
+        new_proxy_type = "system"
+    elif old_proxy_user:
+        new_proxy_type = "custom"
+    elif old_proxy_no:
+        new_proxy_type = "none"
+    else:
+        new_proxy_type = "system"
+
+    fci.Preferences().set("proxy_type", new_proxy_type)
+    fci.Preferences().set("proxy_host", new_proxy_host)
+    fci.Preferences().set("proxy_port", new_proxy_port)
+    fci.Preferences().set("proxy_settings_migrated_2025", True)

--- a/addonmanager_utilities.py
+++ b/addonmanager_utilities.py
@@ -621,7 +621,7 @@ def create_pip_call(args: List[str]) -> List[str]:
         port = fci.Preferences().get("proxy_port")
 
     if use_proxy:
-        call_args.extend(["--proxy", f"https://{host}:{port}"])
+        call_args.extend(["--proxy", f"http://{host}:{port}"])
 
     call_args.extend(args)
     return call_args

--- a/addonmanager_utilities.py
+++ b/addonmanager_utilities.py
@@ -40,7 +40,7 @@ import ctypes
 
 from urllib.parse import urlparse
 
-from PySideWrapper import QtCore, QtGui, QtWidgets
+from PySideWrapper import QtCore, QtGui, QtWidgets, QtNetwork
 
 import addonmanager_freecad_interface as fci
 
@@ -602,5 +602,25 @@ def create_pip_call(args: List[str]) -> List[str]:
         if not python_exe:
             raise RuntimeError("Could not locate Python executable on this system")
         call_args = [python_exe, "-m", "pip", "--disable-pip-version-check"]
+
+    proxy_type = fci.Preferences().get("proxy_type")
+    use_proxy = False
+    host = ""
+    port = 8080
+    if proxy_type == "system":
+        query = QtNetwork.QNetworkProxyQuery(QtCore.QUrl("https://addons.freecad.org/status"))
+        proxies = QtNetwork.QNetworkProxyFactory.systemProxyForQuery(query)
+        if proxies and proxies[0] and proxies[0].hostName() and proxies[0].port() > 0:
+            use_proxy = True
+            host = proxies[0].hostName()
+            port = proxies[0].port()
+    elif proxy_type == "custom":
+        use_proxy = True
+        host = fci.Preferences().get("proxy_host")
+        port = fci.Preferences().get("proxy_port")
+
+    if use_proxy:
+        call_args.extend(["--proxy", f"https://{host}:{port}"])
+
     call_args.extend(args)
     return call_args

--- a/addonmanager_utilities.py
+++ b/addonmanager_utilities.py
@@ -608,7 +608,8 @@ def create_pip_call(args: List[str]) -> List[str]:
     host = ""
     port = 8080
     if proxy_type == "system":
-        query = QtNetwork.QNetworkProxyQuery(QtCore.QUrl("https://addons.freecad.org/status"))
+        url = fci.Preferences().get("status_test_url")
+        query = QtNetwork.QNetworkProxyQuery(QtCore.QUrl(url))
         proxies = QtNetwork.QNetworkProxyFactory.systemProxyForQuery(query)
         if proxies and proxies[0] and proxies[0].hostName() and proxies[0].port() > 0:
             use_proxy = True

--- a/addonmanager_workers_utility.py
+++ b/addonmanager_workers_utility.py
@@ -59,7 +59,7 @@ class ConnectionChecker(QtCore.QThread):
         on it to spawn a child thread."""
 
         fci.Console.PrintLog("Checking network connection...\n")
-        url = "https://addons.freecad.org/status"
+        url = fci.Preferences().get("status_test_url")
         self.done = False
         NetworkManager.AM_NETWORK_MANAGER.completed.connect(self.connection_data_received)
         self.request_id = NetworkManager.AM_NETWORK_MANAGER.submit_unmonitored_get(


### PR DESCRIPTION
The proxy UI was very awkward to use (see #228) -- this implements the GUI redesign proposed by @PhoneDroid (adapted to deal with Qt Widgets workflows). It corrects several technical problems with the use of proxies, and adds proxy support to `pip` calls.

Fixes #228 
Fixes #212

New UI:

https://github.com/user-attachments/assets/76449a68-b75b-479c-baf7-78f9912d8c2e

