### PR TITLE
Implement constraints.txt file to lock in versions

### DIFF
--- a/addonmanager_preferences_defaults.json
+++ b/addonmanager_preferences_defaults.json
@@ -33,5 +33,6 @@
     "last_fetched_macro_cache_hash": "Cache never fetched, no hash available",
     "macro_cache_url": "https://addons.freecad.org/macro_cache.zip",
     "old_backup_handling": "ask",
+    "pip_constraints_url": "https://raw.githubusercontent.com/FreeCAD/FreeCAD-addons/master/constraints.txt",
     "readWarning2022": false
 }

--- a/addonmanager_utilities.py
+++ b/addonmanager_utilities.py
@@ -602,5 +602,13 @@ def create_pip_call(args: List[str]) -> List[str]:
         if not python_exe:
             raise RuntimeError("Could not locate Python executable on this system")
         call_args = [python_exe, "-m", "pip", "--disable-pip-version-check"]
+
     call_args.extend(args)
+
+    # If installing or updating, apply our constraints file
+    if "install" in args or "download" in args or "wheel" in args:
+        constraints = fci.Preferences().get("pip_constraints_url")
+        if constraints:
+            call_args.extend(["-c", constraints])
+
     return call_args


### PR DESCRIPTION
Fixes #220 

Implements a remote `constraints.txt` file that `pip` uses to lock in dependency resolution versions. The initial `constraints.txt` file was generated by installing all ALLOWED_PYTHON_PACKAGES into a virtual environment and then locking them and outputting the requirements file. Dependabot has been configured to scan the constraints file weekly.

An open question is what to do about the four packages that could *not* be installed into that venv:
* `scikit-sparse`
* `wakatime-cli`
* `gmsh-dev`
* `certify`

Right now the `constraints.txt` file is being applied exactly as designed, and any packages *not* listed in it are simply unconstrained. We could consider disallowing the installation of packages not listed in constraints (this will require a bit of coding to get pip to do a dry run and to evaluate if the requirements are all in the constraints file, and if not to refuse the installation).