### PR TITLE
[ Feature ] Multi Tab - License Tab

### DIFF
--- a/Addon.py
+++ b/Addon.py
@@ -221,7 +221,7 @@ class Addon:
         self.python_min_version = Version(from_list=[3, 0, 0])
 
         self._icon_file = None
-        self._cached_license: str | List[License|str] = ""
+        self._cached_license: str | List[License | str] = ""
         self._cached_update_date = None
 
     def __eq__(self, other):

--- a/Addon.py
+++ b/Addon.py
@@ -47,6 +47,7 @@ import addonmanager_utilities as utils
 from addonmanager_metadata import (
     Metadata,
     MetadataReader,
+    License,
     UrlType,
     Version,
     DependencyType,
@@ -220,7 +221,7 @@ class Addon:
         self.python_min_version = Version(from_list=[3, 0, 0])
 
         self._icon_file = None
-        self._cached_license: str = ""
+        self._cached_license: str | List[License|str] = ""
         self._cached_update_date = None
 
     def __eq__(self, other):

--- a/Widgets/addonmanager_widget_package_details_view.py
+++ b/Widgets/addonmanager_widget_package_details_view.py
@@ -22,11 +22,12 @@
 # ***************************************************************************
 
 from dataclasses import dataclass
+from typing import Optional , Dict
 from enum import Enum, auto
 import os
-from typing import Optional
 
 from addonmanager_freecad_interface import translate
+from addonmanager_readme_controller import TabView
 
 from PySideWrapper import QtCore, QtWidgets
 
@@ -71,6 +72,7 @@ class PackageDetailsView(QtWidgets.QWidget):
     def __init__(self, parent: QtWidgets.QWidget = None):
         super().__init__(parent)
         self.button_bar = None
+        self.license_browser = None
         self.readme_browser = None
         self.message_label = None
         self.location_label = None
@@ -83,12 +85,24 @@ class PackageDetailsView(QtWidgets.QWidget):
         self.installed_branch = None
         self.installed_timestamp = None
         self.can_disable = True
+        self.tabs : Dict[ TabView , int ] = {}
         self._setup_ui()
 
     def _setup_ui(self):
         self.vertical_layout = QtWidgets.QVBoxLayout(self)
         self.button_bar = WidgetAddonButtons(self)
+
+        self.license_browser = WidgetReadmeBrowser(self)
         self.readme_browser = WidgetReadmeBrowser(self)
+        
+        self.tabs_widget = QtWidgets.QTabWidget(self)
+
+        self.tabs[ TabView.Readme ] = self.tabs_widget \
+            .addTab(self.readme_browser,translate('AddonsInstaller','README'))
+
+        self.tabs[ TabView.License ] = self.tabs_widget \
+            .addTab(self.license_browser,translate('AddonsInstaller','LICENSE'))
+
         self.message_label = QtWidgets.QLabel(self)
         self.location_label = QtWidgets.QLabel(self)
         self.url_label = QtWidgets.QLabel(self)
@@ -98,7 +112,7 @@ class PackageDetailsView(QtWidgets.QWidget):
         self.vertical_layout.addWidget(self.message_label)
         self.vertical_layout.addWidget(self.location_label)
         self.vertical_layout.addWidget(self.url_label)
-        self.vertical_layout.addWidget(self.readme_browser)
+        self.vertical_layout.addWidget(self.tabs_widget)
         self.button_bar.hide()  # Start with no bar
 
     def set_location(self, location: Optional[str]):

--- a/Widgets/addonmanager_widget_package_details_view.py
+++ b/Widgets/addonmanager_widget_package_details_view.py
@@ -98,11 +98,11 @@ class PackageDetailsView(QtWidgets.QWidget):
         self.tabs_widget = QtWidgets.QTabWidget(self)
 
         self.tabs[TabView.Readme] = self.tabs_widget.addTab(
-            self.readme_browser, translate("AddonsInstaller", "README")
+            self.readme_browser, translate("AddonsInstaller", "Overview")
         )
 
         self.tabs[TabView.License] = self.tabs_widget.addTab(
-            self.license_browser, translate("AddonsInstaller", "LICENSE")
+            self.license_browser, translate("AddonsInstaller", "License")
         )
 
         self.message_label = QtWidgets.QLabel(self)

--- a/Widgets/addonmanager_widget_package_details_view.py
+++ b/Widgets/addonmanager_widget_package_details_view.py
@@ -22,7 +22,7 @@
 # ***************************************************************************
 
 from dataclasses import dataclass
-from typing import Optional , Dict
+from typing import Optional, Dict
 from enum import Enum, auto
 import os
 
@@ -85,7 +85,7 @@ class PackageDetailsView(QtWidgets.QWidget):
         self.installed_branch = None
         self.installed_timestamp = None
         self.can_disable = True
-        self.tabs : Dict[ TabView , int ] = {}
+        self.tabs: Dict[TabView, int] = {}
         self._setup_ui()
 
     def _setup_ui(self):
@@ -94,14 +94,16 @@ class PackageDetailsView(QtWidgets.QWidget):
 
         self.license_browser = WidgetReadmeBrowser(self)
         self.readme_browser = WidgetReadmeBrowser(self)
-        
+
         self.tabs_widget = QtWidgets.QTabWidget(self)
 
-        self.tabs[ TabView.Readme ] = self.tabs_widget \
-            .addTab(self.readme_browser,translate('AddonsInstaller','README'))
+        self.tabs[TabView.Readme] = self.tabs_widget.addTab(
+            self.readme_browser, translate("AddonsInstaller", "README")
+        )
 
-        self.tabs[ TabView.License ] = self.tabs_widget \
-            .addTab(self.license_browser,translate('AddonsInstaller','LICENSE'))
+        self.tabs[TabView.License] = self.tabs_widget.addTab(
+            self.license_browser, translate("AddonsInstaller", "LICENSE")
+        )
 
         self.message_label = QtWidgets.QLabel(self)
         self.location_label = QtWidgets.QLabel(self)

--- a/addonmanager_package_details_controller.py
+++ b/addonmanager_package_details_controller.py
@@ -89,14 +89,15 @@ class PackageDetailsController(QtCore.QObject):
 
         self.addon = addon
 
-        self.readme_controller.set_addon(addon, TabView.Readme)
-
         has_license = bool(self.addon.license)
 
         self.ui.tabs_widget.setTabVisible(self.ui.tabs[TabView.License], has_license)
 
         if has_license:
             self.license_controller.set_addon(addon, TabView.License)
+
+        self.readme_controller.set_addon(addon, TabView.Readme)
+        self.ui.tabs_widget.setCurrentIndex(TabView.Readme)
 
         self.original_disabled_state = self.addon.is_disabled()
 

--- a/addonmanager_package_details_controller.py
+++ b/addonmanager_package_details_controller.py
@@ -33,11 +33,11 @@ from addonmanager_metadata import (
     get_branch_from_metadata,
     get_repo_url_from_metadata,
 )
+from Widgets.addonmanager_widget_package_details_view import PackageDetailsView , UpdateInformation , WarningFlags
+from addonmanager_readme_controller import ReadmeController , TabView
 from addonmanager_workers_startup import CheckSingleUpdateWorker
 from addonmanager_git import GitManager, NoGitFound
 from Addon import Addon
-from addonmanager_readme_controller import ReadmeController
-from Widgets.addonmanager_widget_package_details_view import UpdateInformation, WarningFlags
 
 translate = fci.translate
 
@@ -52,10 +52,13 @@ class PackageDetailsController(QtCore.QObject):
     execute = QtCore.Signal(Addon)
     update_status = QtCore.Signal(Addon)
 
-    def __init__(self, widget=None):
+    def __init__(self, widget : PackageDetailsView ):
         super().__init__()
         self.ui = widget
+        
+        self.license_controller = ReadmeController(self.ui.license_browser)
         self.readme_controller = ReadmeController(self.ui.readme_browser)
+
         self.worker = None
         self.addon = None
         self.update_check_thread = None
@@ -77,11 +80,24 @@ class PackageDetailsController(QtCore.QObject):
         self.ui.button_bar.install_branch.connect(self.install_branch)
 
     def show_addon(self, addon: Addon) -> None:
+
         """The main entry point for this class shows the package details and related buttons
         for the provided repo."""
+        
         self.addon = addon
-        self.readme_controller.set_addon(addon)
+        
+        self.readme_controller.set_addon(addon,TabView.Readme)
+
+        has_license = bool(self.addon.license)
+
+        self.ui.tabs_widget.setTabVisible(self.ui.tabs[ TabView.License ],has_license)
+
+        if has_license:
+            self.license_controller.set_addon(addon,TabView.License)
+
+
         self.original_disabled_state = self.addon.is_disabled()
+        
         if addon is not None:
             self.ui.button_bar.show()
             if addon.repo_type == Addon.Kind.MACRO:

--- a/addonmanager_package_details_controller.py
+++ b/addonmanager_package_details_controller.py
@@ -33,8 +33,12 @@ from addonmanager_metadata import (
     get_branch_from_metadata,
     get_repo_url_from_metadata,
 )
-from Widgets.addonmanager_widget_package_details_view import PackageDetailsView , UpdateInformation , WarningFlags
-from addonmanager_readme_controller import ReadmeController , TabView
+from Widgets.addonmanager_widget_package_details_view import (
+    PackageDetailsView,
+    UpdateInformation,
+    WarningFlags,
+)
+from addonmanager_readme_controller import ReadmeController, TabView
 from addonmanager_workers_startup import CheckSingleUpdateWorker
 from addonmanager_git import GitManager, NoGitFound
 from Addon import Addon
@@ -52,10 +56,10 @@ class PackageDetailsController(QtCore.QObject):
     execute = QtCore.Signal(Addon)
     update_status = QtCore.Signal(Addon)
 
-    def __init__(self, widget : PackageDetailsView ):
+    def __init__(self, widget: PackageDetailsView):
         super().__init__()
         self.ui = widget
-        
+
         self.license_controller = ReadmeController(self.ui.license_browser)
         self.readme_controller = ReadmeController(self.ui.readme_browser)
 
@@ -80,24 +84,22 @@ class PackageDetailsController(QtCore.QObject):
         self.ui.button_bar.install_branch.connect(self.install_branch)
 
     def show_addon(self, addon: Addon) -> None:
-
         """The main entry point for this class shows the package details and related buttons
         for the provided repo."""
-        
+
         self.addon = addon
-        
-        self.readme_controller.set_addon(addon,TabView.Readme)
+
+        self.readme_controller.set_addon(addon, TabView.Readme)
 
         has_license = bool(self.addon.license)
 
-        self.ui.tabs_widget.setTabVisible(self.ui.tabs[ TabView.License ],has_license)
+        self.ui.tabs_widget.setTabVisible(self.ui.tabs[TabView.License], has_license)
 
         if has_license:
-            self.license_controller.set_addon(addon,TabView.License)
-
+            self.license_controller.set_addon(addon, TabView.License)
 
         self.original_disabled_state = self.addon.is_disabled()
-        
+
         if addon is not None:
             self.ui.button_bar.show()
             if addon.repo_type == Addon.Kind.MACRO:

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -27,7 +27,7 @@ from Addon import Addon
 import addonmanager_utilities as utils
 import addonmanager_freecad_interface as fci
 
-from typing import TypedDict, Optional, Dict ,cast
+from typing import TypedDict, Optional, Dict, cast
 from enum import IntEnum, auto
 
 import NetworkManager
@@ -50,9 +50,11 @@ class TabView(IntEnum):
     License = auto()
     Readme = 0
 
+
 class LicenseRequest(TypedDict):
-    license : License
-    text : QtWidgets.QTextEdit
+    license: License
+    text: QtWidgets.QTextEdit
+
 
 class ReadmeController(QtCore.QObject):
     """A class that can provide README data from an Addon, possibly loading external resources such
@@ -63,12 +65,12 @@ class ReadmeController(QtCore.QObject):
         NetworkManager.InitializeNetworkManager()
         NetworkManager.AM_NETWORK_MANAGER.completed.connect(self._download_completed)
         self.readme_request_index = 0
-        
+
         self.resource_requests = {}
         self.resource_failures = []
 
-        self.license_requests : Dict[ int , LicenseRequest ] = {}
-        
+        self.license_requests: Dict[int, LicenseRequest] = {}
+
         self.url = ""
         self.readme_data = None
         self.readme_data_type = None
@@ -126,18 +128,18 @@ class ReadmeController(QtCore.QObject):
             text = None
 
             if code == 200:
-                text = cast(str,data.data().decode('utf-8'))
-            
+                text = cast(str, data.data().decode("utf-8"))
+
             entry = self.license_requests.get(index)
 
-            print('License loaded',index,code,entry)
+            print("License loaded", index, code, entry)
 
             if not entry:
                 return
 
-            text = text or entry[ 'license' ].name
+            text = text or entry["license"].name
 
-            entry[ 'text' ].setText(text)
+            entry["text"].setText(text)
 
     def _process_package_download(self, data: str):
         self.readme_data = data
@@ -148,18 +150,15 @@ class ReadmeController(QtCore.QObject):
         image = QtGui.QImage.fromData(resource_data)
         self.widget.set_resource(resource_name, image)
 
-    def loadLicense ( self , license : License , text : QtWidgets.QTextEdit ):
+    def loadLicense(self, license: License, text: QtWidgets.QTextEdit):
 
-        url = utils.construct_git_url(self.addon,license.file)
+        url = utils.construct_git_url(self.addon, license.file)
 
         manager = NetworkManager.AM_NETWORK_MANAGER
 
         index = manager.submit_unmonitored_get(url)
 
-        self.license_requests[index] = {
-            'license' : license ,
-            'text' : text
-        }
+        self.license_requests[index] = {"license": license, "text": text}
 
     def loadResource(self, full_url: str):
         if full_url not in self.resource_failures:
@@ -240,18 +239,16 @@ class ReadmeController(QtCore.QObject):
             layout = self.widget.layout()
 
             if not layout:
-        
+
                 layout = QtWidgets.QVBoxLayout()
 
                 self.widget.setLayout(layout)
 
-
             while layout.count():
-                
+
                 item = layout.takeAt(0)
                 widget = item.widget()
                 widget.setParent(None)
-
 
             if type(licenses) is list:
 
@@ -261,14 +258,12 @@ class ReadmeController(QtCore.QObject):
 
                     text = QtWidgets.QTextEdit()
 
-                    text.setText(
-                        translate("AddonsInstaller", "Loading license..")
-                    )
+                    text.setText(translate("AddonsInstaller", "Loading license.."))
 
                     layout.addWidget(text)
 
                     if type(license) is License:
-                        self.loadLicense(license,text)
+                        self.loadLicense(license, text)
                     elif type(license) is str:
                         text.setText(license)
 
@@ -287,9 +282,7 @@ class ReadmeController(QtCore.QObject):
                 for url in self.addon.metadata.url:
                     if url.type == UrlType.readme:
                         if self.url != url.location:
-                            fci.Console.PrintLog(
-                                "README url does not match expected location\n"
-                            )
+                            fci.Console.PrintLog("README url does not match expected location\n")
                             fci.Console.PrintLog(f"Expected: {self.url}\n")
                             fci.Console.PrintLog(f"package.xml contents: {url.location}\n")
                             fci.Console.PrintLog(

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -135,7 +135,9 @@ class ReadmeController(QtCore.QObject):
             if code == 200:
                 text = cast(str, data.data().decode("utf-8"))
             else:
-                fci.Console().printLog(f'Failed to fetch license. Name : "{ entry["license"].name }" , File : "{ entry["license"].file }"')
+                fci.Console().printLog(
+                    f'Failed to fetch license. Name : "{ entry["license"].name }" , File : "{ entry["license"].file }"'
+                )
 
             text = text or entry["license"].name
 

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -27,24 +27,24 @@ from Addon import Addon
 import addonmanager_utilities as utils
 import addonmanager_freecad_interface as fci
 
-from requests import get as fetch , ConnectionError
-from typing import Optional , cast
-from enum import IntEnum , auto
+from requests import get as fetch, ConnectionError
+from typing import Optional, cast
+from enum import IntEnum, auto
 
 import NetworkManager
 from Widgets.addonmanager_widget_readme_browser import WidgetReadmeBrowser
-from addonmanager_metadata import UrlType , License
+from addonmanager_metadata import UrlType, License
 
 translate = fci.translate
 
 from PySideWrapper import QtCore, QtGui
 
 
-
 class ReadmeDataType(IntEnum):
     PlainText = 0
     Markdown = 1
     Html = 2
+
 
 class TabView(IntEnum):
     License = auto()
@@ -55,7 +55,7 @@ class ReadmeController(QtCore.QObject):
     """A class that can provide README data from an Addon, possibly loading external resources such
     as images"""
 
-    def __init__(self, widget : WidgetReadmeBrowser ):
+    def __init__(self, widget: WidgetReadmeBrowser):
         super().__init__()
         NetworkManager.InitializeNetworkManager()
         NetworkManager.AM_NETWORK_MANAGER.completed.connect(self._download_completed)
@@ -71,7 +71,7 @@ class ReadmeController(QtCore.QObject):
         self.widget.load_resource.connect(self.loadResource)
         self.widget.follow_link.connect(self.follow_link)
 
-    def set_addon ( self , addon : Addon , view : TabView ):
+    def set_addon(self, addon: Addon, view: TabView):
         """Set which Addon's information is displayed"""
 
         self.addon = addon
@@ -110,7 +110,9 @@ class ReadmeController(QtCore.QObject):
                     else:
                         self.widget.setText(self.readme_data)
                 else:
-                    self.set_addon(self.addon,TabView.Readme)  # Trigger a reload of the page now with resources
+                    self.set_addon(
+                        self.addon, TabView.Readme
+                    )  # Trigger a reload of the page now with resources
 
     def _process_package_download(self, data: str):
         self.readme_data = data
@@ -189,21 +191,21 @@ class ReadmeController(QtCore.QObject):
         self.readme_data_type = ReadmeDataType.Markdown
         self.widget.setMarkdown(markdown)
 
-    def _create_non_wiki_display ( self , view : TabView ):
+    def _create_non_wiki_display(self, view: TabView):
 
         match view:
             case TabView.License:
 
-                addon = cast(Addon,self.addon)
+                addon = cast(Addon, self.addon)
 
                 licenses = addon.license
 
                 match licenses:
                     case list():
 
-                        text = ''
+                        text = ""
 
-                        licenses = cast(list[License | str],licenses)
+                        licenses = cast(list[License | str], licenses)
 
                         for license in licenses:
                             if license == str():
@@ -212,10 +214,10 @@ class ReadmeController(QtCore.QObject):
 
                                 name = license.name
 
-                                url = utils.construct_git_url(addon,license.file)
+                                url = utils.construct_git_url(addon, license.file)
 
                                 try:
-                                     
+
                                     response = fetch(url)
 
                                     if response.ok:
@@ -226,7 +228,7 @@ class ReadmeController(QtCore.QObject):
                                 except ConnectionError:
 
                                     text += name
-                                
+
                         self.widget.setText(text)
 
                     case str():
@@ -235,12 +237,14 @@ class ReadmeController(QtCore.QObject):
             case TabView.Readme:
 
                 self.url = utils.get_readme_url(self.addon)
-            
+
                 if self.addon.metadata and self.addon.metadata.url:
                     for url in self.addon.metadata.url:
                         if url.type == UrlType.readme:
                             if self.url != url.location:
-                                fci.Console.PrintLog("README url does not match expected location\n")
+                                fci.Console.PrintLog(
+                                    "README url does not match expected location\n"
+                                )
                                 fci.Console.PrintLog(f"Expected: {self.url}\n")
                                 fci.Console.PrintLog(f"package.xml contents: {url.location}\n")
                                 fci.Console.PrintLog(
@@ -275,7 +279,6 @@ class ReadmeController(QtCore.QObject):
                     with open(self.url, "r") as fd:
                         self._process_package_download("".join(fd.readlines()))
                 else:
-                    self.readme_request_index = NetworkManager.AM_NETWORK_MANAGER.submit_unmonitored_get(
-                        self.url
+                    self.readme_request_index = (
+                        NetworkManager.AM_NETWORK_MANAGER.submit_unmonitored_get(self.url)
                     )
-

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -132,8 +132,6 @@ class ReadmeController(QtCore.QObject):
 
             entry = self.license_requests.get(index)
 
-            print("License loaded", index, code, entry)
-
             if not entry:
                 return
 

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -27,7 +27,7 @@ from Addon import Addon
 import addonmanager_utilities as utils
 import addonmanager_freecad_interface as fci
 
-from typing import TypedDict, Optional, Dict, cast
+from typing import TypedDict, Optional, Dict
 from enum import IntEnum, auto
 
 import NetworkManager

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -130,7 +130,7 @@ class ReadmeController(QtCore.QObject):
             if not entry:
                 return
 
-            text : None | str = None
+            text: None | str = None
 
             if code == 200:
                 text = data.data().decode("utf-8")
@@ -235,7 +235,7 @@ class ReadmeController(QtCore.QObject):
         if view == TabView.License:
 
             addon = self.addon
-            
+
             if not addon:
                 return
 

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -125,15 +125,17 @@ class ReadmeController(QtCore.QObject):
 
         elif index in self.license_requests:
 
-            text = None
-
-            if code == 200:
-                text = cast(str, data.data().decode("utf-8"))
-
             entry = self.license_requests.get(index)
 
             if not entry:
                 return
+
+            text = None
+
+            if code == 200:
+                text = cast(str, data.data().decode("utf-8"))
+            else:
+                fci.Console().printLog(f'Failed to fetch license. Name : "{ entry["license"].name }" , File : "{ entry["license"].file }"')
 
             text = text or entry["license"].name
 

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -130,10 +130,10 @@ class ReadmeController(QtCore.QObject):
             if not entry:
                 return
 
-            text = None
+            text : None | str = None
 
             if code == 200:
-                text = cast(str, data.data().decode("utf-8"))
+                text = data.data().decode("utf-8")
             else:
                 fci.Console.PrintLog(
                     f'Failed to fetch license. Name : "{ entry["license"].name }" , File : "{ entry["license"].file }"'
@@ -234,7 +234,10 @@ class ReadmeController(QtCore.QObject):
 
         if view == TabView.License:
 
-            addon = cast(Addon, self.addon)
+            addon = self.addon
+            
+            if not addon:
+                return
 
             licenses = addon.license
 
@@ -253,8 +256,6 @@ class ReadmeController(QtCore.QObject):
                 widget.setParent(None)
 
             if type(licenses) is list:
-
-                licenses = cast(list[License | str], licenses)
 
                 for license in licenses:
 

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -135,7 +135,7 @@ class ReadmeController(QtCore.QObject):
             if code == 200:
                 text = cast(str, data.data().decode("utf-8"))
             else:
-                fci.Console().printLog(f'Failed to fetch license. Name : "{ entry["license"].name }" , File : "{ entry["license"].file }"')
+                fci.Console.PrintLog(f'Failed to fetch license. Name : "{ entry["license"].name }" ,File : "{ entry["license"].file }"')
 
             text = text or entry["license"].name
 


### PR DESCRIPTION
Inspired by the work done [here](https://github.com/FreeCAD/FreeCAD/pull/18199)

I decided to go with a minimal  
approach for my own implementation.

- Adds multi tabs to addon overviews.
- Adds a `License` tab

Help wanted, if someone with Python async knowledge  
could make this not block the UI, that's be just great ..

<br/>

### Implementation Notes

I decided to have mapping of the tabs to their tab indices  
to not have to hard code them and keep them in sync.

The license text is currently just dumped in the  
tab, for now I just wanted to get it to work.
