### PR TITLE
Update patternProperties regex in schema

### DIFF
--- a/AddonCatalog.schema.json
+++ b/AddonCatalog.schema.json
@@ -24,7 +24,7 @@
     }
   },
   "patternProperties": {
-    "^.+$": {
+    "^(?!\\$schema$|_meta$).+$": {
       "type": "array",
       "items": {
         "type": "object",


### PR DESCRIPTION
Make sure that the "$schema" and "_meta" properties aren't being matched in the patternProperties section, since they are explicitly handled above.