### PR TITLE
[AddonManager] Allow Manifest migration to continue by skipping file …

### DIFF
--- a/addonmanager_installation_manifest.py
+++ b/addonmanager_installation_manifest.py
@@ -84,24 +84,27 @@ class InstallationManifest:
             os.makedirs(fci.DataPaths().mod_dir)
         dirs_in_mod = os.listdir(fci.DataPaths().mod_dir)
         for addon_id in dirs_in_mod:
-            branches = []
-            if catalog:
-                branches = catalog.get_available_branches(addon_id)
-            if branches:
-                branch_display_name = branches[0]
-                self._manifest[addon_id] = {
-                    "addon_id": addon_id,
-                    "migrated": True,
-                    "first_installed": datetime.datetime.fromtimestamp(
-                        0, tz=datetime.timezone.utc
-                    ).isoformat(),
-                    "last_updated": most_recent_update(
-                        os.path.join(fci.DataPaths().mod_dir, addon_id)
-                    ).isoformat(),
-                    "branch_display_name": branch_display_name,
-                    "extra_files": [],
-                    "freecad_version": "",
-                }
+            if Path(os.path.join(fci.DataPaths().mod_dir, addon_id)).is_dir():
+                branches = []
+                if catalog:
+                    branches = catalog.get_available_branches(addon_id)
+                if branches:
+                    branch_display_name = branches[0]
+                    self._manifest[addon_id] = {
+                        "addon_id": addon_id,
+                        "migrated": True,
+                        "first_installed": datetime.datetime.fromtimestamp(
+                            0, tz=datetime.timezone.utc
+                        ).isoformat(),
+                        "last_updated": most_recent_update(
+                            os.path.join(fci.DataPaths().mod_dir, addon_id)
+                        ).isoformat(),
+                        "branch_display_name": branch_display_name,
+                        "extra_files": [],
+                        "freecad_version": "",
+                    }
+            else:
+                fci.Console.PrintMessage("Migrate to Manifest, skipping file: " + addon_id + "\n")
 
     def load_manifest(self):
         """Load the manifest from the disk"""


### PR DESCRIPTION
…with same name as Addon

I hit the following on my 0.21 build:

```
Traceback (most recent call last):
  File "/home/username/.local/share/FreeCAD/Mod/AddonManager/./addonmanager_workers_startup.py", line 82, in run
    self.process_addon_cache(addon_cache)
  File "/home/username/.local/share/FreeCAD/Mod/AddonManager/./addonmanager_workers_startup.py", line 228, in process_addon_cache
    manifest = InstallationManifest(catalog)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/username/.local/share/FreeCAD/Mod/AddonManager/./addonmanager_installation_manifest.py", line 75, in __init__
    self._migrate_to_manifest_file(catalog)
  File "/home/username/.local/share/FreeCAD/Mod/AddonManager/./addonmanager_installation_manifest.py", line 98, in _migrate_to_manifest_file
    "last_updated": most_recent_update(
                    ^^^^^^^^^^^^^^^^^^^
  File "/home/username/.local/share/FreeCAD/Mod/AddonManager/./addonmanager_installation_manifest.py", line 42, in most_recent_update
    raise NotADirectoryError(f"Path is not a directory: {path}")
NotADirectoryError: Path is not a directory: /home/username/.local/share/FreeCAD/Mod/FreeCAD-Ribbon
```

causing FreeCAD to freeze and having to kill it. This PR is the solution I came up with in these _very_ rare circumstances.