### PR TITLE
[ Feature ] Contains Filter Option

### DIFF
--- a/Addon.py
+++ b/Addon.py
@@ -491,6 +491,20 @@ class Addon:
         """Determine if this package contains an "other" content item"""
         return self.contains_packaged_content("other")
 
+    def contains_no_generated_content(self) -> bool:
+        """Determines if this package explicitly contains no generated content"""
+
+        if self.repo_type != Addon.Kind.PACKAGE:
+            return False
+
+        if not self.metadata:
+            return False
+
+        if not self.metadata.contains:
+            return False
+
+        return self.metadata.contains.generated_content == False
+
     def walk_dependency_tree(self, all_repos: Dict[str, "Addon"], deps: Dependencies):
         """Compute the total dependency tree for this repo (recursive)
         - all_repos is a dictionary of repos, keyed on the name of the repo

--- a/addonmanager_preferences_defaults.json
+++ b/addonmanager_preferences_defaults.json
@@ -15,6 +15,7 @@
     "MacroUpdateStatsURL": "https://addons.freecad.org/macro_update_stats.json",
     "NoProxyCheck": false,
     "PackageTypeSelection": 0,
+    "ContainsSelection": "" ,
     "ProxyUrl": "",
     "SearchString": "",
     "SelectedAddon": "",


### PR DESCRIPTION
~~Not quite sure how to best test it since the~~ 
~~manager ignores the local addons manifest ..~~

Added the metadata to Polyhedra and it seems to work ( Preview 2 )

Adds a new filter option ( Contains ) that currently only 
has one option ( No generated content ) that allows to 
explicitly search for addons that declare they don't
contain any generated content.

This option - unlike the rest - actually behaves as the UI
suggests, as a checkbox, not sure why the other radio groups 
use checkboxes O.o ?

On purpose does not add another state in the name 
of the dropdown, just adding more and more to that 
doesn't seem like a good idea.

To make this option useful I'd submit PRs to the various addon 
repositories to declare if / not they contain generated content.

## Preview
<img height="300"  alt="image" src="https://github.com/user-attachments/assets/b6d5db4b-236d-4fdd-9ce8-13412c779f03" />

<img width="1357" height="381" alt="image" src="https://github.com/user-attachments/assets/3f27a9bf-629e-47ae-85ed-6a2c1787bdad" />


## Manifest

```xml
<contains generated_content = 'true' />
<contains generated_content = 'false' />
```
