### PR TITLE
Improve error recording for macro cache generation

### DIFF
--- a/AddonManagerTest/app/test_freecad_interface.py
+++ b/AddonManagerTest/app/test_freecad_interface.py
@@ -75,39 +75,34 @@ class TestConsole(WrapTestFreeCADImports):
         """Test that if the FreeCAD import fails, the logger is set up correctly, and
         implements PrintLog"""
         sys.modules["FreeCAD"] = None
-        with patch("addonmanager_freecad_interface.logging", new=MagicMock()) as mock_logging:
-            import addonmanager_freecad_interface as fc
+        import addonmanager_freecad_interface as fc
 
+        with self.assertLogs("addonmanager", level="DEBUG") as cm:
             fc.Console.PrintLog("Test output")
-            self.assertTrue(isinstance(fc.Console, fc.ConsoleReplacement))
-            self.assertTrue(mock_logging.log.called)
 
     def test_message_no_freecad(self):
         """Test that if the FreeCAD import fails the logger implements PrintMessage"""
         sys.modules["FreeCAD"] = None
-        with patch("addonmanager_freecad_interface.logging", new=MagicMock()) as mock_logging:
-            import addonmanager_freecad_interface as fc
+        import addonmanager_freecad_interface as fc
 
+        with self.assertLogs("addonmanager", level="INFO") as cm:
             fc.Console.PrintMessage("Test output")
-            self.assertTrue(mock_logging.info.called)
 
     def test_warning_no_freecad(self):
         """Test that if the FreeCAD import fails the logger implements PrintWarning"""
         sys.modules["FreeCAD"] = None
-        with patch("addonmanager_freecad_interface.logging", new=MagicMock()) as mock_logging:
-            import addonmanager_freecad_interface as fc
+        import addonmanager_freecad_interface as fc
 
+        with self.assertLogs("addonmanager", level="WARNING") as cm:
             fc.Console.PrintWarning("Test output")
-            self.assertTrue(mock_logging.warning.called)
 
     def test_error_no_freecad(self):
         """Test that if the FreeCAD import fails the logger implements PrintError"""
         sys.modules["FreeCAD"] = None
-        with patch("addonmanager_freecad_interface.logging", new=MagicMock()) as mock_logging:
-            import addonmanager_freecad_interface as fc
+        import addonmanager_freecad_interface as fc
 
+        with self.assertLogs("addonmanager", level="ERROR") as cm:
             fc.Console.PrintError("Test output")
-            self.assertTrue(mock_logging.error.called)
 
 
 class TestParameters(WrapTestFreeCADImports):

--- a/addonmanager_freecad_interface.py
+++ b/addonmanager_freecad_interface.py
@@ -107,6 +107,8 @@ except ImportError:
     getUserMacroDir = None
     loadUi = None
 
+    logger = logging.getLogger("addonmanager")
+
     try:
         from PySide6 import QtCore, QtWidgets
 
@@ -154,19 +156,19 @@ except ImportError:
 
         @staticmethod
         def PrintLog(arg: str) -> None:
-            logging.log(logging.DEBUG, arg)
+            logger.log(logging.DEBUG, arg)
 
         @staticmethod
         def PrintMessage(arg: str) -> None:
-            logging.info(arg)
+            logger.info(arg)
 
         @staticmethod
         def PrintWarning(arg: str) -> None:
-            logging.warning(arg)
+            logger.warning(arg)
 
         @staticmethod
         def PrintError(arg: str) -> None:
-            logging.error(arg)
+            logger.error(arg)
 
     Console = ConsoleReplacement()
 

--- a/addonmanager_macro_parser.py
+++ b/addonmanager_macro_parser.py
@@ -203,17 +203,23 @@ class MacroParser:
             self.parse_results["comment"] = self.parse_results["comment"][:511] + "…"
 
     def _cleanup_license(self):
+        if len(self.parse_results["license"].strip()) == 0:
+            fci.Console.PrintWarning(
+                f"No license specified for macro {self.name} -- assuming 'All rights reserved'.\n"
+            )
+            self.parse_results["license"] = "All rights reserved"
+            return
         if get_license_manager is not None:
             lm = get_license_manager()
             normed_license = lm.normalize(self.parse_results["license"])
             if not normed_license:
                 fci.Console.PrintWarning(
-                    f"Failed to normalize license {self.parse_results['license']} for macro '{self.name}'\n"
+                    f"Failed to normalize license '{self.parse_results['license']}' for macro '{self.name}'\n"
                 )
                 return
             elif normed_license != self.parse_results["license"]:
                 fci.Console.PrintMessage(
-                    f"Normalized license {self.parse_results['license']} for macro '{self.name}' to {normed_license}\n"
+                    f"Normalized license '{self.parse_results['license']}' for macro '{self.name}' to {normed_license}\n"
                 )
                 self.parse_results["license"] = normed_license
 


### PR DESCRIPTION
Catch the console error output from the macro class while it builds the macros, and record it to a developer-visible log location on addons.freecad.org.