### PR TITLE
Cleanup reported issues

### DIFF
--- a/.github/workflows/qt6-tests.yml
+++ b/.github/workflows/qt6-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pyfakefs "PySide6<6.11" vermin requests || true
+          pip install pyfakefs "PySide6<6.11" vermin requests defusedxml || true
 
       - name: Run App tests
         run: |

--- a/Addon.py
+++ b/Addon.py
@@ -29,7 +29,7 @@ from urllib.parse import urlparse, urlunparse
 from typing import Dict, Set, List, Optional
 from threading import Lock
 from enum import IntEnum, auto
-import xml.etree.ElementTree
+from xml.etree.ElementTree import ParseError as XmlParseError
 
 try:
     import importlib.metadata as importlib_metadata
@@ -320,7 +320,7 @@ class Addon:
         if os.path.exists(file):
             try:
                 metadata = MetadataReader.from_file(file)
-            except xml.etree.ElementTree.ParseError:
+            except XmlParseError:
                 fci.Console.PrintWarning(
                     "An invalid or corrupted package.xml file was found in the cache for"
                 )
@@ -339,7 +339,7 @@ class Addon:
         if os.path.isfile(installed_metadata_path):
             try:
                 self.installed_metadata = MetadataReader.from_file(installed_metadata_path)
-            except xml.etree.ElementTree.ParseError:
+            except XmlParseError:
                 fci.Console.PrintWarning(
                     "An invalid or corrupted package.xml file was found in installation of"
                 )

--- a/AddonCatalog.py
+++ b/AddonCatalog.py
@@ -25,7 +25,7 @@ sources and compatible versions. Added in FreeCAD 1.1 to replace .gitmodules."""
 import base64
 import datetime
 import os
-import xml.etree.ElementTree
+from xml.etree.ElementTree import ParseError as XmlParseError
 from dataclasses import dataclass
 import json
 from hashlib import sha256
@@ -156,7 +156,7 @@ class AddonCatalogEntry:
         if self.metadata:
             try:
                 self._load_addon_metadata(addon, self.metadata)
-            except xml.etree.ElementTree.ParseError:
+            except XmlParseError:
                 fci.Console.PrintWarning(
                     "An invalid or corrupted package.xml file was installed "
                     f"for {addon.display_name}\n"
@@ -170,7 +170,7 @@ class AddonCatalogEntry:
             try:
                 package_file = os.path.join(fci.DataPaths().mod_dir, addon_id, "package.xml")
                 addon.installed_metadata = MetadataReader.from_file(package_file)
-            except (FileNotFoundError, xml.etree.ElementTree.ParseError, RuntimeError):
+            except (FileNotFoundError, XmlParseError, RuntimeError):
                 pass  # If there was an error, just ignore it, no metadata is not fatal
 
             most_recent_mtime = AddonCatalogEntry.most_recent_mtime(addon_id)

--- a/AddonCatalogCacheCreator.py
+++ b/AddonCatalogCacheCreator.py
@@ -39,7 +39,7 @@ import re
 import requests
 import subprocess
 from typing import List
-import xml.etree.ElementTree
+from xml.etree.ElementTree import ParseError as XmlParseError
 import zipfile
 
 import AddonCatalog
@@ -311,7 +311,7 @@ class CacheWriter:
             metadata = addonmanager_metadata.MetadataReader.from_bytes(
                 cache_entry.package_xml.encode("utf-8")
             )
-        except xml.etree.ElementTree.ParseError:
+        except XmlParseError:
             print(f"ERROR: Failed to parse XML from {path_to_package_xml}")
             return None
         except RuntimeError:

--- a/Resources/translations/run_translation_cycle.py
+++ b/Resources/translations/run_translation_cycle.py
@@ -36,7 +36,7 @@ import tempfile
 import time
 from functools import lru_cache
 from urllib.parse import quote_plus
-from urllib.request import Request, urlopen, urlretrieve
+from urllib.request import Request, urlopen, urlretrieve, urlparse
 
 CROWDIN_API_URL = "https://api.crowdin.com/api/v2"
 CROWDIN_API_PROJECT_ID = "freecad-addons"
@@ -85,6 +85,9 @@ class CrowdinUpdater:
             headers["Content-Type"] = "application/json"
             data = json.dumps(data).encode("utf-8")
 
+        parsed_url = urlparse(url)
+        if parsed_url.scheme != "https":
+            raise Exception("API requests must be made over HTTPS")
         request = Request(url, headers=headers, method=method, data=data)
         request_result = urlopen(request)
         if request_result.getcode() >= 300:
@@ -136,6 +139,11 @@ class CrowdinUpdater:
     def download(self, build_id):
         filename = f"{self.project_identifier}.zip"
         response = self._make_project_api_req(f"/translations/builds/{build_id}/download")
+
+        parsed_url = urlparse(response["url"])
+        if parsed_url.scheme != "https":
+            raise Exception("API requests must be made over HTTPS")
+
         urlretrieve(response["url"], filename)
         print("download of " + filename + " complete")
 

--- a/Resources/translations/run_translation_cycle.py
+++ b/Resources/translations/run_translation_cycle.py
@@ -35,8 +35,8 @@ import sys
 import tempfile
 import time
 from functools import lru_cache
-from urllib.parse import quote_plus
-from urllib.request import Request, urlopen, urlretrieve, urlparse
+from urllib.parse import quote_plus, urlparse
+from urllib.request import Request, urlopen, urlretrieve
 
 CROWDIN_API_URL = "https://api.crowdin.com/api/v2"
 CROWDIN_API_PROJECT_ID = "freecad-addons"

--- a/addonmanager_icon_utilities.py
+++ b/addonmanager_icon_utilities.py
@@ -19,19 +19,13 @@
 #                                                                              #
 ################################################################################
 
+import defusedxml.ElementTree as ET
 import re
 import os
 import struct
 from typing import Optional, List
 
 from PySideWrapper import QtCore, QtGui, QtSvg
-
-try:
-    # If this system provides a secure parser, use that:
-    import defusedxml.ElementTree as ET
-except ImportError:
-    # Otherwise fall back to the Python standard parser
-    import xml.etree.ElementTree as ET
 
 from Addon import Addon
 import addonmanager_freecad_interface as fci

--- a/addonmanager_metadata.py
+++ b/addonmanager_metadata.py
@@ -25,17 +25,11 @@ https://wiki.FreeCAD.org/Package_metadata"""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import defusedxml.ElementTree as ET
 from enum import IntEnum, auto
 from typing import Tuple, Dict, List, Optional
 
 from addonmanager_licenses import get_license_manager
-
-try:
-    # If this system provides a secure parser, use that:
-    import defusedxml.ElementTree as ET
-except ImportError:
-    # Otherwise fall back to the Python standard parser
-    import xml.etree.ElementTree as ET
 
 
 @dataclass

--- a/addonmanager_utilities.py
+++ b/addonmanager_utilities.py
@@ -423,6 +423,11 @@ def blocking_get(url: str, method=None) -> bytes:
     succeeded, or an empty string if it failed, or returned no data. The method argument is
     provided mainly for testing purposes."""
     p = b""
+    parse_result = urllib.parse.urlparse(url)
+    if parse_result.scheme != "http" and parse_result.scheme != "https":
+        raise ValueError(
+            f"Invalid URL scheme: {parse_result.scheme} (only http and https are supported)"
+        )
     if (
         fci.FreeCADGui
         and method is None

--- a/addonmanager_utilities.py
+++ b/addonmanager_utilities.py
@@ -424,10 +424,8 @@ def blocking_get(url: str, method=None) -> bytes:
     provided mainly for testing purposes."""
     p = b""
     parse_result = urllib.parse.urlparse(url)
-    if parse_result.scheme != "http" and parse_result.scheme != "https":
-        raise ValueError(
-            f"Invalid URL scheme: {parse_result.scheme} (only http and https are supported)"
-        )
+    if parse_result.scheme != "https":
+        raise ValueError(f"Invalid URL scheme: {parse_result.scheme} (only https is supported)")
     if (
         fci.FreeCADGui
         and method is None

--- a/addonmanager_workers_startup.py
+++ b/addonmanager_workers_startup.py
@@ -588,14 +588,8 @@ class UpdateChecker:
             macro_wrapper.set_status(Addon.Status.CANNOT_CHECK)
             return
 
-        try:
-            hasher1 = hashlib.sha1(usedforsecurity=False)
-            hasher2 = hashlib.sha1(usedforsecurity=False)
-        except TypeError:
-            # To continue to support Python 3.8, we need to fall back if the usedforsecurity
-            # is not available. This code should be removed when we drop support for 3.8.
-            hasher1 = hashlib.sha1()
-            hasher2 = hashlib.sha1()
+        hasher1 = hashlib.sha1(usedforsecurity=False)
+        hasher2 = hashlib.sha1(usedforsecurity=False)
         hasher1.update(macro_wrapper.macro.code.encode("utf-8"))
         new_sha1 = hasher1.hexdigest()
         test_file_one = os.path.join(fci.DataPaths().macro_dir, macro_wrapper.macro.filename)

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
             FreeCAD prior to 1.1 can see the InitGui.py file and run it. -->
             <name>AddonManager</name>
             <subdirectory>./</subdirectory>
+            <depend optional="false" type="python">defusedxml</depend>
         </workbench>
     </content>
 </package>


### PR DESCRIPTION
Remove fallback to regular Python XML parser, forcing use of `defusedxml`, and eliminate backwards-compatibility of SHA1 generator for Python 3.8, adding the `usedforsecurity=False` flag.