### PR TITLE
Fix custom repository metadata and icon loading

### DIFF
--- a/AddonManagerTest/app/test_workers_startup.py
+++ b/AddonManagerTest/app/test_workers_startup.py
@@ -23,7 +23,7 @@ import json
 import unittest
 from unittest.mock import patch, MagicMock
 import addonmanager_workers_startup
-
+from Addon import Addon
 from PySideWrapper import QtCore
 
 
@@ -155,3 +155,217 @@ class TestCreateAddonListWorker(unittest.TestCase):
 
         # Assert
         self.assertEqual(8, mock_addon_repo_signal.emit.call_count)
+
+
+# ---------------------------------------------------------------------------
+# Minimal package.xml used by the tests below.  The <url> tag intentionally
+# carries a *different* branch than the custom-repo entry so we can verify
+# that the original values are preserved.
+# ---------------------------------------------------------------------------
+_PACKAGE_XML_WITH_ICON = b"""\
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+  <name>My Custom Addon</name>
+  <description>A description from package.xml.</description>
+  <version>1.0.0</version>
+  <date>2024-01-01</date>
+  <maintainer email="dev@example.com">Dev</maintainer>
+  <license file="LICENSE">LGPL-2.1</license>
+  <url type="repository" branch="wrong-branch">https://github.com/example/wrong-repo</url>
+  <icon>Resources/icons/MyIcon.svg</icon>
+</package>
+"""
+
+_PACKAGE_XML_NO_ICON = b"""\
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+  <name>My Custom Addon</name>
+  <description>A description from package.xml.</description>
+  <version>1.0.0</version>
+  <date>2024-01-01</date>
+  <maintainer email="dev@example.com">Dev</maintainer>
+  <license file="LICENSE">LGPL-2.1</license>
+  <url type="repository" branch="wrong-branch">https://github.com/example/wrong-repo</url>
+</package>
+"""
+
+_FAKE_ICON_BYTES = b"\x89PNG\r\n\x1a\nfake-icon-data"
+
+
+def _make_network_reply(data: bytes) -> MagicMock:
+    """Return a mock mimicking a successful QNetworkReply-like response."""
+    reply = MagicMock()
+    reply.data.return_value = data
+    return reply
+
+
+class TestFetchRemoteCustomAddonMetadata(unittest.TestCase):
+    """Unit tests for CreateAddonListWorker._fetch_remote_custom_addon_metadata."""
+
+    _CUSTOM_URL = "https://github.com/myorg/my-custom-addon"
+    _CUSTOM_BRANCH = "main"
+
+    def _make_repo(self) -> Addon:
+        return Addon(
+            name="MyCustomAddon",
+            url=self._CUSTOM_URL,
+            branch=self._CUSTOM_BRANCH,
+        )
+
+    def _make_worker(self) -> addonmanager_workers_startup.CreateAddonListWorker:
+        return addonmanager_workers_startup.CreateAddonListWorker()
+
+    # ------------------------------------------------------------------
+    # Happy path: package.xml fetched, icon fetched
+    # ------------------------------------------------------------------
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_metadata_fields_populated(self, mock_nm, _mock_console):
+        """display_name and description are taken from the fetched package.xml."""
+        mock_nm.blocking_get_with_retries.side_effect = [
+            _make_network_reply(_PACKAGE_XML_WITH_ICON),  # package.xml fetch
+            _make_network_reply(_FAKE_ICON_BYTES),  # icon fetch
+        ]
+
+        repo = self._make_repo()
+        self._make_worker()._fetch_remote_custom_addon_metadata(repo)
+
+        self.assertEqual("My Custom Addon", repo.display_name)
+        self.assertEqual("A description from package.xml.", repo.description)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_icon_data_populated(self, mock_nm, _mock_console):
+        """icon_data is set from the fetched icon bytes."""
+        mock_nm.blocking_get_with_retries.side_effect = [
+            _make_network_reply(_PACKAGE_XML_WITH_ICON),
+            _make_network_reply(_FAKE_ICON_BYTES),
+        ]
+
+        repo = self._make_repo()
+        self._make_worker()._fetch_remote_custom_addon_metadata(repo)
+
+        self.assertEqual(_FAKE_ICON_BYTES, repo.icon_data)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_custom_url_preserved(self, mock_nm, _mock_console):
+        """repo.url must remain the custom-repo URL, not the one from package.xml."""
+        mock_nm.blocking_get_with_retries.side_effect = [
+            _make_network_reply(_PACKAGE_XML_WITH_ICON),
+            _make_network_reply(_FAKE_ICON_BYTES),
+        ]
+
+        repo = self._make_repo()
+        self._make_worker()._fetch_remote_custom_addon_metadata(repo)
+
+        self.assertEqual(self._CUSTOM_URL, repo.url)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_custom_branch_preserved(self, mock_nm, _mock_console):
+        """repo.branch must remain the custom-repo branch, not the one from package.xml."""
+        mock_nm.blocking_get_with_retries.side_effect = [
+            _make_network_reply(_PACKAGE_XML_WITH_ICON),
+            _make_network_reply(_FAKE_ICON_BYTES),
+        ]
+
+        repo = self._make_repo()
+        self._make_worker()._fetch_remote_custom_addon_metadata(repo)
+
+        self.assertEqual(self._CUSTOM_BRANCH, repo.branch)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_icon_url_uses_custom_branch(self, mock_nm, _mock_console):
+        """The icon is fetched using the custom branch, not the one from package.xml."""
+        mock_nm.blocking_get_with_retries.side_effect = [
+            _make_network_reply(_PACKAGE_XML_WITH_ICON),
+            _make_network_reply(_FAKE_ICON_BYTES),
+        ]
+
+        repo = self._make_repo()
+        self._make_worker()._fetch_remote_custom_addon_metadata(repo)
+
+        # The icon URL should contain the custom branch, not "wrong-branch"
+        icon_call_args = mock_nm.blocking_get_with_retries.call_args_list[1]
+        icon_url: str = icon_call_args[0][0]
+        self.assertIn(self._CUSTOM_BRANCH, icon_url)
+        self.assertNotIn("wrong-branch", icon_url)
+
+    # ------------------------------------------------------------------
+    # No icon in package.xml
+    # ------------------------------------------------------------------
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_no_icon_field_skips_icon_fetch(self, mock_nm, _mock_console):
+        """When package.xml has no <icon>, only one network call is made."""
+        mock_nm.blocking_get_with_retries.return_value = _make_network_reply(_PACKAGE_XML_NO_ICON)
+
+        repo = self._make_repo()
+        self._make_worker()._fetch_remote_custom_addon_metadata(repo)
+
+        self.assertEqual(1, mock_nm.blocking_get_with_retries.call_count)
+
+    # ------------------------------------------------------------------
+    # Failure cases – should be silent / non-fatal
+    # ------------------------------------------------------------------
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_no_package_xml_available(self, mock_nm, _mock_console):
+        """When the network returns None, the repo is left unchanged."""
+        mock_nm.blocking_get_with_retries.return_value = None
+
+        repo = self._make_repo()
+        self._make_worker()._fetch_remote_custom_addon_metadata(repo)
+
+        self.assertIsNone(repo.metadata)
+        self.assertEqual(self._CUSTOM_URL, repo.url)
+        self.assertEqual(self._CUSTOM_BRANCH, repo.branch)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_network_exception_leaves_repo_unchanged(self, mock_nm, _mock_console):
+        """A network error during package.xml fetch leaves the repo unchanged."""
+        mock_nm.blocking_get_with_retries.side_effect = RuntimeError("connection refused")
+
+        repo = self._make_repo()
+        self._make_worker()._fetch_remote_custom_addon_metadata(repo)
+
+        self.assertIsNone(repo.metadata)
+        self.assertEqual(self._CUSTOM_URL, repo.url)
+        self.assertEqual(self._CUSTOM_BRANCH, repo.branch)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_corrupt_package_xml_leaves_repo_unchanged(self, mock_nm, _mock_console):
+        """Invalid XML during parse leaves the repo unchanged."""
+        mock_nm.blocking_get_with_retries.return_value = _make_network_reply(b"this is not xml")
+
+        repo = self._make_repo()
+        self._make_worker()._fetch_remote_custom_addon_metadata(repo)
+
+        self.assertIsNone(repo.metadata)
+        self.assertEqual(self._CUSTOM_URL, repo.url)
+        self.assertEqual(self._CUSTOM_BRANCH, repo.branch)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_icon_fetch_failure_does_not_raise(self, mock_nm, _mock_console):
+        """A network error during icon fetch is silently swallowed."""
+        mock_nm.blocking_get_with_retries.side_effect = [
+            _make_network_reply(_PACKAGE_XML_WITH_ICON),
+            RuntimeError("icon fetch failed"),
+        ]
+
+        repo = self._make_repo()
+        # Must not raise:
+        self._make_worker()._fetch_remote_custom_addon_metadata(repo)
+
+        # Metadata should still be populated, just no icon
+        self.assertIsNotNone(repo.metadata)
+        self.assertEqual(self._CUSTOM_URL, repo.url)
+        self.assertEqual(self._CUSTOM_BRANCH, repo.branch)

--- a/addonmanager_workers_startup.py
+++ b/addonmanager_workers_startup.py
@@ -40,6 +40,7 @@ from AddonStats import AddonStats
 import NetworkManager
 from addonmanager_git import initialize_git, GitFailed
 from addonmanager_metadata import MetadataReader, get_branch_from_metadata
+import addonmanager_utilities as utils
 import addonmanager_freecad_interface as fci
 
 translate = fci.translate
@@ -130,16 +131,79 @@ class CreateAddonListWorker(QtCore.QThread):
                 md_file = os.path.join(addon_dir, "package.xml")
                 if os.path.isfile(md_file):
                     try:
-                        repo.installed_metadata = MetadataReader.from_file(md_file)
-                        repo.installed_version = repo.installed_metadata.version
-                        repo.updated_timestamp = os.path.getmtime(md_file)
-                        repo.verify_url_and_branch(addon["url"], addon["branch"])
+                        # load_metadata_file calls set_metadata(), populating repo.metadata,
+                        # repo.description, repo.display_name etc. for the UI to display.
+                        repo.load_metadata_file(md_file)
+                        if repo.metadata:
+                            repo.installed_metadata = repo.metadata
+                            repo.installed_version = repo.metadata.version
+                            repo.updated_timestamp = os.path.getmtime(md_file)
+                            repo.verify_url_and_branch(addon["url"], addon["branch"])
+                            # Load icon bytes from the local install directory so the
+                            # list view can display the addon's actual icon.
+                            if repo.metadata.icon:
+                                icon_file = os.path.join(addon_dir, repo.metadata.icon)
+                                if os.path.isfile(icon_file):
+                                    try:
+                                        with open(icon_file, "rb") as f:
+                                            repo.icon_data = f.read()
+                                    except OSError as e:
+                                        fci.Console.PrintWarning(
+                                            f"Could not load icon for custom addon {name}: {e}\n"
+                                        )
                     except xml.etree.ElementTree.ParseError:
                         fci.Console.PrintWarning(
                             f"An invalid or corrupted package.xml file was installed for custom addon {name}... ignoring the bad data.\n"
                         )
+                else:
+                    # Not installed: try to fetch package.xml from the remote repo so the
+                    # browse view can show description and icon.
+                    self._fetch_remote_custom_addon_metadata(repo)
 
                 self.addon_repo.emit(repo)
+
+    def _fetch_remote_custom_addon_metadata(self, repo: Addon) -> None:
+        """For a custom addon that is not yet installed, attempt to fetch its package.xml
+        from the remote repo so the browse view can show the description and display name.
+        Failures are non-fatal: the addon will simply show without metadata."""
+
+        package_xml_url = utils.construct_git_url(repo, "package.xml")
+        fci.Console.PrintLog(f"Fetching remote metadata for custom addon {repo.name} from {package_xml_url}\n")
+        try:
+            result = NetworkManager.AM_NETWORK_MANAGER.blocking_get_with_retries(
+                package_xml_url,
+                CreateAddonListWorker.ATTEMPT_TIMEOUT_MS,
+                1,  # single attempt – don't slow down startup for missing files
+                0,
+            )
+        except Exception as e:
+            fci.Console.PrintLog(f"Could not fetch remote package.xml for custom addon {repo.name}: {e}\n")
+            return
+
+        if not result:
+            fci.Console.PrintLog(f"No package.xml found at {package_xml_url} for custom addon {repo.name}\n")
+            return
+
+        try:
+            metadata = MetadataReader.from_bytes(result.data())
+            repo.set_metadata(metadata)
+        except Exception as e:
+            fci.Console.PrintWarning(f"Could not parse remote package.xml for custom addon {repo.name}: {e}\n")
+            return
+
+        if repo.metadata and repo.metadata.icon:
+            icon_url = utils.construct_git_url(repo, repo.metadata.icon)
+            try:
+                icon_result = NetworkManager.AM_NETWORK_MANAGER.blocking_get_with_retries(
+                    icon_url,
+                    CreateAddonListWorker.ATTEMPT_TIMEOUT_MS,
+                    1,
+                    0,
+                )
+                if icon_result:
+                    repo.icon_data = icon_result.data()
+            except Exception as e:
+                fci.Console.PrintLog(f"Could not fetch remote icon for custom addon {repo.name}: {e}\n")
 
     def get_cache(self, cache_name: str) -> str:
         cache_file_name = cache_name + "_cache.json"

--- a/addonmanager_workers_startup.py
+++ b/addonmanager_workers_startup.py
@@ -168,7 +168,9 @@ class CreateAddonListWorker(QtCore.QThread):
         Failures are non-fatal: the addon will simply show without metadata."""
 
         package_xml_url = utils.construct_git_url(repo, "package.xml")
-        fci.Console.PrintLog(f"Fetching remote metadata for custom addon {repo.name} from {package_xml_url}\n")
+        fci.Console.PrintLog(
+            f"Fetching remote metadata for custom addon {repo.name} from {package_xml_url}\n"
+        )
         try:
             result = NetworkManager.AM_NETWORK_MANAGER.blocking_get_with_retries(
                 package_xml_url,
@@ -177,18 +179,24 @@ class CreateAddonListWorker(QtCore.QThread):
                 0,
             )
         except Exception as e:
-            fci.Console.PrintLog(f"Could not fetch remote package.xml for custom addon {repo.name}: {e}\n")
+            fci.Console.PrintLog(
+                f"Could not fetch remote package.xml for custom addon {repo.name}: {e}\n"
+            )
             return
 
         if not result:
-            fci.Console.PrintLog(f"No package.xml found at {package_xml_url} for custom addon {repo.name}\n")
+            fci.Console.PrintLog(
+                f"No package.xml found at {package_xml_url} for custom addon {repo.name}\n"
+            )
             return
 
         try:
             metadata = MetadataReader.from_bytes(result.data())
             repo.set_metadata(metadata)
         except Exception as e:
-            fci.Console.PrintWarning(f"Could not parse remote package.xml for custom addon {repo.name}: {e}\n")
+            fci.Console.PrintWarning(
+                f"Could not parse remote package.xml for custom addon {repo.name}: {e}\n"
+            )
             return
 
         if repo.metadata and repo.metadata.icon:
@@ -203,7 +211,9 @@ class CreateAddonListWorker(QtCore.QThread):
                 if icon_result:
                     repo.icon_data = icon_result.data()
             except Exception as e:
-                fci.Console.PrintLog(f"Could not fetch remote icon for custom addon {repo.name}: {e}\n")
+                fci.Console.PrintLog(
+                    f"Could not fetch remote icon for custom addon {repo.name}: {e}\n"
+                )
 
     def get_cache(self, cache_name: str) -> str:
         cache_file_name = cache_name + "_cache.json"

--- a/addonmanager_workers_startup.py
+++ b/addonmanager_workers_startup.py
@@ -27,7 +27,6 @@ import io
 import json
 import os
 from typing import List
-import xml.etree.ElementTree
 import zipfile
 
 from PySideWrapper import QtCore
@@ -130,31 +129,27 @@ class CreateAddonListWorker(QtCore.QThread):
                 repo = Addon(name, addon["url"], state, addon["branch"])
                 md_file = os.path.join(addon_dir, "package.xml")
                 if os.path.isfile(md_file):
-                    try:
-                        # load_metadata_file calls set_metadata(), populating repo.metadata,
-                        # repo.description, repo.display_name etc. for the UI to display.
-                        repo.load_metadata_file(md_file)
-                        if repo.metadata:
-                            repo.installed_metadata = repo.metadata
-                            repo.installed_version = repo.metadata.version
-                            repo.updated_timestamp = os.path.getmtime(md_file)
-                            repo.verify_url_and_branch(addon["url"], addon["branch"])
-                            # Load icon bytes from the local install directory so the
-                            # list view can display the addon's actual icon.
-                            if repo.metadata.icon:
-                                icon_file = os.path.join(addon_dir, repo.metadata.icon)
-                                if os.path.isfile(icon_file):
-                                    try:
-                                        with open(icon_file, "rb") as f:
-                                            repo.icon_data = f.read()
-                                    except OSError as e:
-                                        fci.Console.PrintWarning(
-                                            f"Could not load icon for custom addon {name}: {e}\n"
-                                        )
-                    except xml.etree.ElementTree.ParseError:
-                        fci.Console.PrintWarning(
-                            f"An invalid or corrupted package.xml file was installed for custom addon {name}... ignoring the bad data.\n"
-                        )
+                    # load_metadata_file calls set_metadata(), populating repo.metadata,
+                    # repo.description, repo.display_name etc. for the UI to display.
+                    # It handles ParseError internally, leaving repo.metadata as None on failure.
+                    repo.load_metadata_file(md_file)
+                    if repo.metadata:
+                        repo.installed_metadata = repo.metadata
+                        repo.installed_version = repo.metadata.version
+                        repo.updated_timestamp = os.path.getmtime(md_file)
+                        repo.verify_url_and_branch(addon["url"], addon["branch"])
+                        # Load icon bytes from the local install directory so the
+                        # list view can display the addon's actual icon.
+                        if repo.metadata.icon:
+                            icon_file = os.path.join(addon_dir, repo.metadata.icon)
+                            if os.path.isfile(icon_file):
+                                try:
+                                    with open(icon_file, "rb") as f:
+                                        repo.icon_data = f.read()
+                                except OSError as e:
+                                    fci.Console.PrintWarning(
+                                        f"Could not load icon for custom addon {name}: {e}\n"
+                                    )
                 else:
                     # Not installed: try to fetch package.xml from the remote repo so the
                     # browse view can show description and icon.
@@ -190,6 +185,9 @@ class CreateAddonListWorker(QtCore.QThread):
             )
             return
 
+        original_url = repo.url
+        original_branch = repo.branch
+
         try:
             metadata = MetadataReader.from_bytes(result.data())
             repo.set_metadata(metadata)
@@ -198,6 +196,10 @@ class CreateAddonListWorker(QtCore.QThread):
                 f"Could not parse remote package.xml for custom addon {repo.name}: {e}\n"
             )
             return
+
+        repo.verify_url_and_branch(original_url, original_branch)
+        repo.url = original_url
+        repo.branch = original_branch
 
         if repo.metadata and repo.metadata.icon:
             icon_url = utils.construct_git_url(repo, repo.metadata.icon)


### PR DESCRIPTION
Fix loading and displaying metadata and icons for custom repositories, including remote fetch for not-installed addons.

addonmanager_workers_startup.py:
* Use load_metadata_file and load icon data for installed custom addons
* Add _fetch_remote_custom_addon_metadata to fetch metadata and icon for not-installed custom addons

I reported this issue on the wrong repo: https://github.com/FreeCAD/AddonManager/issues/377

This PR should fix this.