### PR TITLE
Eliminate the exception from blocking_get

### DIFF
--- a/addonmanager_utilities.py
+++ b/addonmanager_utilities.py
@@ -425,7 +425,10 @@ def blocking_get(url: str, method=None) -> bytes:
     p = b""
     parse_result = urlparse(url)
     if parse_result.scheme != "https":
-        raise ValueError(f"Invalid URL scheme: {parse_result.scheme} (only https is supported)")
+        fci.Console.PrintWarning(
+            f"Invalid URL scheme: {parse_result.scheme} (only https is supported)"
+        )
+        return p
     if (
         fci.FreeCADGui
         and method is None


### PR DESCRIPTION
Calling code expects an empty byte string in the event of an error, no caller handles any exceptions.