### PR TITLE
Update package manager menu text and tooltip

### DIFF
--- a/addonmanager_python_deps_commands.py
+++ b/addonmanager_python_deps_commands.py
@@ -36,11 +36,11 @@ class Std_AddonMgrPip:
             "Pixmap": "applications-python.svg",
             "MenuText": QT_TRANSLATE_NOOP(
                 "AddonsInstaller",
-                "Python package manager",
+                "Python Package Manager",
             ),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "AddonsInstaller",
-                "Open python packages manager",
+                "Open the Python Package Manager",
             ),
         }
 

--- a/addonmanager_python_deps_commands.py
+++ b/addonmanager_python_deps_commands.py
@@ -40,7 +40,7 @@ class Std_AddonMgrPip:
             ),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "AddonsInstaller",
-                "Open the Python Package Manager",
+                "Opens the Python Package Manager",
             ),
         }
 


### PR DESCRIPTION
Menu text in title case.
Tooltip: "Opens" instead of "open". Use caps as "Python Package Manager" is the name of the feature.