### PR TITLE
Add custom-repo host detection

### DIFF
--- a/AddonManagerTest/app/test_utilities.py
+++ b/AddonManagerTest/app/test_utilities.py
@@ -20,6 +20,7 @@
 ################################################################################
 
 from datetime import datetime
+import json
 import unittest
 from unittest.mock import MagicMock, patch, mock_open
 import os
@@ -27,12 +28,26 @@ import subprocess
 
 from AddonManagerTest.app.mocks import MockAddon as Addon
 
+from addonmanager_freecad_interface import Preferences
 from addonmanager_utilities import (
+    GITEA,
+    GITHUB,
+    GITLAB,
+    IDENTIFIED_HOSTS_PREFERENCE,
+    construct_git_url,
+    forget_git_host,
+    forget_git_hosts,
     get_assigned_string_literal,
     get_macro_version_from_file,
+    get_readme_html_url,
     get_readme_url,
+    get_zip_url,
+    git_host_of,
+    identify_git_host,
     process_date_string_to_python_datetime,
     recognized_git_location,
+    reload_git_hosts,
+    remember_git_host,
     run_interruptable_subprocess,
 )
 
@@ -93,6 +108,36 @@ class TestUtilities(unittest.TestCase):
             repo = Addon("Test Repo", url, "Addon.Status.NOT_INSTALLED", branch)
             actual_result = get_readme_url(repo)
             self.assertEqual(actual_result, expected_result)
+
+    def test_get_readme_html_url(self):
+        """Each git host displays a file at its own URL: the Gitea hosts, including Codeberg, do
+        not use the same one as GitHub."""
+        expected_urls = {
+            "https://github.com/FreeCAD/FreeCAD": "https://github.com/FreeCAD/FreeCAD/blob/main/README.md",
+            "https://codeberg.org/user/addon": "https://codeberg.org/user/addon/src/branch/main/README.md",
+            "https://gitlab.com/freecad/FreeCAD": "https://gitlab.com/freecad/FreeCAD/-/blob/main/README.md",
+            "https://unknown.host/user/addon": "https://unknown.host/user/addon/-/blob/main/README.md",
+        }
+        for url, expected_result in expected_urls.items():
+            repo = Addon("Test Repo", url, "Addon.Status.NOT_INSTALLED", "main")
+            self.assertEqual(expected_result, get_readme_html_url(repo))
+
+    def test_get_zip_url(self):
+        expected_urls = {
+            "https://github.com/FreeCAD/FreeCAD": "https://github.com/FreeCAD/FreeCAD/archive/main.zip",
+            "https://codeberg.org/user/addon": "https://codeberg.org/user/addon/archive/main.zip",
+            "https://gitlab.com/freecad/FreeCAD": "https://gitlab.com/freecad/FreeCAD/-/archive/main/Test Repo-main.zip",
+            "https://unknown.host/user/addon": "https://unknown.host/user/addon/-/archive/main/Test Repo-main.zip",
+        }
+        for url, expected_result in expected_urls.items():
+            repo = Addon("Test Repo", url, "Addon.Status.NOT_INSTALLED", "main")
+            self.assertEqual(expected_result, get_zip_url(repo))
+
+    def test_construct_git_url_for_a_local_path(self):
+        """A repo that is a local path, rather than a remote host, is used as-is."""
+        repo = Addon("Test Repo", "/home/user/addon", "Addon.Status.NOT_INSTALLED", "main")
+
+        self.assertEqual("/home/user/addon/package.xml", construct_git_url(repo, "package.xml"))
 
     def test_get_assigned_string_literal(self):
         good_lines = [
@@ -267,6 +312,207 @@ class TestUtilities(unittest.TestCase):
             with self.subTest(separator=separator):
                 with self.assertRaises(ValueError):
                     process_date_string_to_python_datetime(f"2024{separator}01{separator}31")
+
+
+class TestGitHostDetection(unittest.TestCase):
+    """Tests for identifying the software that an unrecognized git host is running."""
+
+    _UNKNOWN_URL = "https://git.example.com/user/addon"
+
+    def setUp(self):
+        forget_git_hosts()
+        self.addCleanup(forget_git_hosts)
+
+    def _repo(self, url: str = _UNKNOWN_URL):
+        return Addon("Test Repo", url, "Addon.Status.NOT_INSTALLED", "main")
+
+    def _answers_at(self, *layouts):
+        """A serves_file() that answers only at the raw file layouts of the given hosts, and
+        records every URL it was asked about."""
+        answering_urls = {
+            f"{self._UNKNOWN_URL}{suffix}"
+            for suffix in (
+                {
+                    GITHUB: "/raw/main/package.xml",
+                    GITEA: "/raw/branch/main/package.xml",
+                    GITLAB: "/-/raw/main/package.xml",
+                }[host]
+                for host in layouts
+            )
+        }
+        self.asked = []
+
+        def serves_file(url):
+            self.asked.append(url)
+            return url in answering_urls
+
+        return serves_file
+
+    # The layouts each host was measured to serve. All three serve GitHub's, so it identifies
+    # nothing on its own; the other two layouts are each served only by their own software.
+
+    def test_a_host_serving_only_the_github_layout_is_github(self):
+        self.assertEqual(GITHUB, identify_git_host(self._repo(), self._answers_at(GITHUB)))
+
+    def test_a_host_serving_the_gitea_layout_is_gitea(self):
+        """Gitea serves GitHub's layout as well as its own: the exclusive layout decides."""
+        self.assertEqual(GITEA, identify_git_host(self._repo(), self._answers_at(GITEA, GITHUB)))
+
+    def test_a_host_serving_the_gitlab_layout_is_gitlab(self):
+        """GitLab serves GitHub's layout as well as its own: the exclusive layout decides."""
+        self.assertEqual(GITLAB, identify_git_host(self._repo(), self._answers_at(GITLAB, GITHUB)))
+
+    def test_the_answer_does_not_depend_on_the_order_of_the_layouts(self):
+        """Every layout is asked before anything is decided, so no host can win by being asked
+        first. A Gitea host is identified as Gitea whichever way round the answers arrive."""
+        for order in ((GITEA, GITHUB), (GITHUB, GITEA)):
+            with self.subTest(order=[host.name for host in order]):
+                self.assertEqual(GITEA, identify_git_host(self._repo(), self._answers_at(*order)))
+
+    def test_every_layout_is_asked_about(self):
+        """No early exit: the decision is made from the complete set of answers."""
+        identify_git_host(self._repo(), self._answers_at(GITEA, GITHUB))
+
+        self.assertEqual(
+            {
+                f"{self._UNKNOWN_URL}/raw/main/package.xml",
+                f"{self._UNKNOWN_URL}/raw/branch/main/package.xml",
+                f"{self._UNKNOWN_URL}/-/raw/main/package.xml",
+            },
+            set(self.asked),
+        )
+
+    def test_a_host_serving_an_exclusive_layout_alone_is_still_identified(self):
+        """If a GitLab ever stops serving GitHub's legacy layout, it is still a GitLab."""
+        self.assertEqual(GITLAB, identify_git_host(self._repo(), self._answers_at(GITLAB)))
+
+    def test_a_host_that_contradicts_itself_is_not_identified(self):
+        """Nothing can be both a Gitea and a GitLab. A host that answers at both exclusive layouts
+        is answering everything it is asked, so its answers mean nothing and it is left alone."""
+        self.assertIsNone(identify_git_host(self._repo(), self._answers_at(GITHUB, GITEA, GITLAB)))
+
+    def test_a_host_that_serves_nothing_is_not_identified(self):
+        self.assertIsNone(identify_git_host(self._repo(), self._answers_at()))
+
+    def test_a_local_path_is_not_identified(self):
+        repo = self._repo("/home/user/addon")
+
+        self.assertIsNone(identify_git_host(repo, self._answers_at(GITHUB)))
+
+    def test_identified_host_is_used_for_every_url(self):
+        """A host identified while fetching one file is used for the zip and readme URLs too."""
+        repo = self._repo()
+
+        remember_git_host(repo, GITEA)
+
+        self.assertEqual(f"{self._UNKNOWN_URL}/archive/main.zip", get_zip_url(repo))
+        self.assertEqual(
+            f"{self._UNKNOWN_URL}/src/branch/main/README.md", get_readme_html_url(repo)
+        )
+        self.assertEqual(f"{self._UNKNOWN_URL}/raw/branch/main/README.md", get_readme_url(repo))
+
+    def test_a_known_host_cannot_be_overridden(self):
+        """The layouts of the hosts the Addon Manager ships are not up for redefinition."""
+        repo = self._repo("https://github.com/FreeCAD/FreeCAD")
+
+        remember_git_host(repo, GITLAB)
+
+        self.assertEqual(GITHUB, git_host_of(repo))
+
+    def test_an_unidentified_host_has_no_layout(self):
+        self.assertIsNone(git_host_of(self._repo()))
+
+    def test_forgetting_hosts_makes_them_be_identified_again(self):
+        repo = self._repo()
+        remember_git_host(repo, GITEA)
+
+        forget_git_hosts()
+
+        self.assertIsNone(git_host_of(repo))
+
+
+class TestGitHostPersistence(unittest.TestCase):
+    """A git host does not change which software it runs from one run of FreeCAD to the next, so
+    what was worked out about it is stored in the preferences rather than probed for every time."""
+
+    _UNKNOWN_URL = "https://git.example.com/user/addon"
+
+    def setUp(self):
+        forget_git_hosts()
+        self.addCleanup(forget_git_hosts)
+
+    def _repo(self, url: str = _UNKNOWN_URL):
+        return Addon("Test Repo", url, "Addon.Status.NOT_INSTALLED", "main")
+
+    @staticmethod
+    def _restart():
+        """Simulate the next run of FreeCAD: everything held in memory is gone, and only what was
+        written to the preferences is left."""
+        reload_git_hosts()
+
+    def test_an_identified_host_is_stored_in_the_preferences(self):
+        remember_git_host(self._repo(), GITEA)
+
+        stored = json.loads(Preferences().get(IDENTIFIED_HOSTS_PREFERENCE))
+
+        self.assertEqual({"git.example.com": "Gitea"}, stored)
+
+    def test_an_identified_host_survives_a_restart(self):
+        remember_git_host(self._repo(), GITEA)
+
+        self._restart()
+
+        self.assertEqual(GITEA, git_host_of(self._repo()))
+
+    def test_a_stored_host_is_not_probed_again(self):
+        """A host read back from the preferences is used as-is: nothing is asked of it."""
+        remember_git_host(self._repo(), GITEA)
+
+        self._restart()
+
+        def must_not_be_asked(url):
+            raise AssertionError(f"A host already stored in the preferences was probed at {url}")
+
+        self.assertEqual(GITEA, git_host_of(self._repo()))
+        self.assertEqual(GITEA, identify_git_host(self._repo(), must_not_be_asked))
+
+    def test_forgetting_a_host_removes_it_from_the_preferences(self):
+        repo = self._repo()
+        remember_git_host(repo, GITEA)
+
+        self.assertTrue(forget_git_host(repo))
+
+        self._restart()
+        self.assertIsNone(git_host_of(repo))
+
+    def test_forgetting_a_host_that_was_never_identified_does_nothing(self):
+        """Nothing was learned about this host, so there is no point in trying again."""
+        self.assertFalse(forget_git_host(self._repo()))
+
+    def test_a_host_stored_under_a_name_we_do_not_know_is_ignored(self):
+        """A preference naming host software this version does not support, perhaps written by a
+        newer version, is discarded rather than trusted."""
+        Preferences().set(IDENTIFIED_HOSTS_PREFERENCE, '{"git.example.com": "Fossil"}')
+
+        self._restart()
+
+        self.assertIsNone(git_host_of(self._repo()))
+
+    def test_a_corrupt_preference_is_ignored(self):
+        Preferences().set(IDENTIFIED_HOSTS_PREFERENCE, "this is not JSON")
+
+        self._restart()
+
+        with patch("addonmanager_utilities.fci.Console"):
+            self.assertIsNone(git_host_of(self._repo()))
+
+    def test_a_shipped_host_cannot_be_overridden_by_the_preference(self):
+        """A stored preference cannot redefine the layout of a host we ship support for."""
+        Preferences().set(IDENTIFIED_HOSTS_PREFERENCE, '{"github.com": "GitLab"}')
+
+        self._restart()
+
+        self.assertEqual(GITHUB, git_host_of(self._repo("https://github.com/FreeCAD/FreeCAD")))
 
 
 if __name__ == "__main__":

--- a/AddonManagerTest/app/test_workers_startup.py
+++ b/AddonManagerTest/app/test_workers_startup.py
@@ -22,8 +22,10 @@
 import json
 import os
 import tempfile
+from types import SimpleNamespace
 import unittest
 from unittest.mock import patch, MagicMock
+import addonmanager_utilities as utils
 import addonmanager_workers_startup
 from Addon import Addon
 from PySideWrapper import QtCore
@@ -204,6 +206,153 @@ def _serve(files: dict):
         return None
 
     return get
+
+
+def _serve_urls(urls: dict):
+    """Return a blocking_get_with_retries side effect that serves the given files, keyed on the
+    complete URL, and returns None for every other URL."""
+
+    def get(url: str, *_args, **_kwargs):
+        if url in urls:
+            return _make_network_reply(urls[url])
+        return None
+
+    return get
+
+
+class TestCustomAddonOnAnUnknownHost(unittest.TestCase):
+    """Tests for a custom repository on a git host the Addon Manager does not ship support for,
+    which is only usable if the Addon Manager works out what software the host is running."""
+
+    _NAME = "addon"
+    _URL = "https://git.example.com/user/addon"
+    _BRANCH = "main"
+
+    # This self-hosted Gitea only serves the Gitea URL layout
+    _GITEA_PACKAGE_XML = f"{_URL}/raw/branch/{_BRANCH}/package.xml"
+    _GITEA_ICON = f"{_URL}/raw/branch/{_BRANCH}/Resources/icons/MyIcon.svg"
+
+    def setUp(self):
+        self.mod_dir = tempfile.TemporaryDirectory()
+        data_paths_patch = patch("AddonCatalog.fci.DataPaths")
+        mock_data_paths = data_paths_patch.start()
+        mock_data_paths.return_value.mod_dir = self.mod_dir.name
+        self.addCleanup(data_paths_patch.stop)
+        self.addCleanup(self.mod_dir.cleanup)
+
+        utils.forget_git_hosts()
+        self.addCleanup(utils.forget_git_hosts)
+
+    def _create_addon(self) -> Addon:
+        worker = addonmanager_workers_startup.CreateAddonListWorker()
+        worker.mod_dir = self.mod_dir.name
+        return worker._create_custom_addon(self._NAME, self._URL, self._BRANCH)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_metadata_is_found_by_probing(self, mock_network_manager, _):
+        """The metadata of an addon on an unknown host is found by trying each known URL layout."""
+        mock_network_manager.blocking_get_with_retries.side_effect = _serve_urls(
+            {self._GITEA_PACKAGE_XML: _package_xml("1.0.0"), self._GITEA_ICON: _FAKE_ICON_BYTES}
+        )
+
+        addon = self._create_addon()
+
+        self.assertEqual("My Custom Addon", addon.display_name)
+        self.assertEqual(_FAKE_ICON_BYTES, addon.icon_data)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_the_host_is_identified(self, mock_network_manager, _):
+        """The host that answered is remembered, so the addon's other URLs are built for it. This
+        is what makes the addon installable: its zip lives at a Gitea URL, not a GitLab one."""
+        mock_network_manager.blocking_get_with_retries.side_effect = _serve_urls(
+            {self._GITEA_PACKAGE_XML: _package_xml("1.0.0", icon=False)}
+        )
+
+        addon = self._create_addon()
+
+        self.assertEqual(utils.GITEA, utils.git_host_of(addon))
+        self.assertEqual(f"{self._URL}/archive/{self._BRANCH}.zip", addon.get_zip_url())
+        self.assertEqual(
+            f"{self._URL}/src/branch/{self._BRANCH}/README.md", utils.get_readme_html_url(addon)
+        )
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_an_identified_host_is_not_probed_again(self, mock_network_manager, _):
+        """Once the host has been identified from the first file, every later file is fetched from
+        the layout that worked, rather than probing for it all over again."""
+        mock_network_manager.blocking_get_with_retries.side_effect = _serve_urls(
+            {self._GITEA_PACKAGE_XML: _package_xml("1.0.0"), self._GITEA_ICON: _FAKE_ICON_BYTES}
+        )
+
+        self._create_addon()
+
+        requested = [
+            call[0][0] for call in mock_network_manager.blocking_get_with_retries.call_args_list
+        ]
+        self.assertEqual([self._GITEA_ICON], [url for url in requested if url.endswith(".svg")])
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_a_host_that_answers_nothing_is_not_identified(self, mock_network_manager, _):
+        """A host that provides none of the files is left unidentified, rather than being recorded
+        as whichever layout was tried last."""
+        mock_network_manager.blocking_get_with_retries.side_effect = _serve_urls({})
+
+        addon = self._create_addon()
+
+        self.assertIsNone(utils.git_host_of(addon))
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_a_host_behind_a_login_is_not_identified(self, mock_network_manager, _):
+        """A git host that requires a login answers every URL, including a nonsense one, with a 200
+        and a sign-in page. Its answers say nothing about what software it runs, and the sign-in
+        page must not be mistaken for the addon's metadata."""
+        sign_in_page = b"<!DOCTYPE html>\n<html><body>Please sign in</body></html>"
+        mock_network_manager.blocking_get_with_retries.side_effect = lambda url, *_a, **_k: (
+            _make_network_reply(sign_in_page)
+        )
+
+        addon = self._create_addon()
+
+        self.assertIsNone(utils.git_host_of(addon))
+        self.assertIsNone(addon.metadata)
+        self.assertFalse(addon.python_requires)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_a_sign_in_page_is_never_read_as_a_requirements_file(self, mock_network_manager, _):
+        """The plain text metadata files cannot be checked by parsing them, so a sign-in page
+        served in place of one would otherwise be read as a list of Python dependencies, and the
+        user would be offered its JavaScript to install."""
+        sign_in_page = b"<!DOCTYPE html>\n<html>\n<script>var gl = {};</script>\n</html>"
+        mock_network_manager.blocking_get_with_retries.side_effect = lambda url, *_a, **_k: (
+            _make_network_reply(sign_in_page)
+        )
+
+        addon = self._create_addon()
+
+        self.assertFalse(addon.python_requires)
+        self.assertFalse(addon.requires)
+
+    @patch("addonmanager_workers_startup.fci.Console")
+    @patch("addonmanager_workers_startup.NetworkManager.AM_NETWORK_MANAGER")
+    def test_a_host_that_changed_software_is_identified_again(self, mock_network_manager, _):
+        """A host identified on an earlier run is stored in the preferences, so if it later moves
+        to different software it has to be worked out again rather than staying wrong forever."""
+        remembered = SimpleNamespace(url=self._URL, branch=self._BRANCH, name=self._NAME)
+        utils.remember_git_host(remembered, utils.GITLAB)  # What it was running last time
+        mock_network_manager.blocking_get_with_retries.side_effect = _serve_urls(
+            {self._GITEA_PACKAGE_XML: _package_xml("1.0.0", icon=False)}  # What it runs now
+        )
+
+        addon = self._create_addon()
+
+        self.assertEqual(utils.GITEA, utils.git_host_of(addon))
+        self.assertEqual("My Custom Addon", addon.display_name)
 
 
 class TestCustomAddons(unittest.TestCase):

--- a/addonmanager_preferences_defaults.json
+++ b/addonmanager_preferences_defaults.json
@@ -11,6 +11,7 @@
     "HideNonFSFFreeLibre": false,
     "HideNonOSIApproved": false,
     "HideUnlicensed": false,
+    "IdentifiedGitHosts": "{}",
     "KnownPythonVersions": "[]",
     "MacroUpdateStatsURL": "https://addons.freecad.org/macro_update_stats.json",
     "NoProxyCheck": false,

--- a/addonmanager_utilities.py
+++ b/addonmanager_utilities.py
@@ -24,14 +24,17 @@
 
 # pylint: disable=deprecated-module, ungrouped-imports
 
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, Any, List
+from typing import Dict, Optional, Any, List, Tuple
+import json
 import os
 import platform
 import shutil
 import stat
 import subprocess
 import sys
+import threading
 import time
 import re
 import ctypes
@@ -197,58 +200,237 @@ def restart_freecad():
         QtCore.QProcess.startDetached(QtWidgets.QApplication.applicationFilePath(), args)
 
 
+@dataclass(frozen=True)
+class GitHost:
+    """The URL layouts used by a family of git hosting software. Each layout is a format string
+    that takes the base url of the repository, the branch, the name of the addon, and the path of
+    a file within the repository.
+
+    raw_file_is_exclusive records whether a host that serves a file at this raw_file layout must be
+    running this software. Gitea and GitLab each have a raw file layout that only they serve, but
+    all three of them serve GitHub's, so being answered at GitHub's layout means nothing on its own.
+    See identify_git_host()."""
+
+    name: str
+    raw_file: str
+    archive: str
+    blob: str
+    raw_file_is_exclusive: bool
+
+
+GITHUB = GitHost(
+    name="GitHub",
+    raw_file="{url}/raw/{branch}/{filename}",
+    archive="{url}/archive/{branch}.zip",
+    blob="{url}/blob/{branch}/{filename}",
+    raw_file_is_exclusive=False,  # Gitea and GitLab serve this layout too
+)
+
+GITEA = GitHost(
+    name="Gitea",  # Also Forgejo (and therefore Codeberg)
+    raw_file="{url}/raw/branch/{branch}/{filename}",
+    archive="{url}/archive/{branch}.zip",
+    blob="{url}/src/branch/{branch}/{filename}",
+    raw_file_is_exclusive=True,
+)
+
+GITLAB = GitHost(
+    name="GitLab",
+    raw_file="{url}/-/raw/{branch}/{filename}",
+    archive="{url}/-/archive/{branch}/{name}-{branch}.zip",
+    blob="{url}/-/blob/{branch}/{filename}",
+    raw_file_is_exclusive=True,
+)
+
+KNOWN_GIT_HOSTS: Dict[str, GitHost] = {
+    "github.com": GITHUB,
+    "codeberg.org": GITEA,
+    "gitlab.com": GITLAB,
+    "framagit.org": GITLAB,
+    "salsa.debian.org": GITLAB,
+}
+
+# Every host that an unidentified git host might turn out to be running. All of them are asked, and
+# the answer is worked out from the complete set of replies, so the order here does not matter.
+CANDIDATE_GIT_HOSTS: Tuple[GitHost, ...] = (GITHUB, GITEA, GITLAB)
+
+# The layout to use for a host that we have neither heard of nor identified
+DEFAULT_GIT_HOST = GITLAB
+
+# The file a host is asked for when identifying it. It has to be one whose contents can be checked,
+# so that a login page or an error page served with a 200 status is not mistaken for it.
+IDENTIFYING_FILE = "package.xml"
+
+GIT_HOSTS_BY_NAME: Dict[str, GitHost] = {host.name: host for host in CANDIDATE_GIT_HOSTS}
+
+# The preference that identified hosts are stored in, so that a host only ever has to be identified
+# once: a host does not change which software it runs from one run of FreeCAD to the next.
+IDENTIFIED_HOSTS_PREFERENCE = "IdentifiedGitHosts"
+
+_identified_git_hosts: Optional[Dict[str, GitHost]] = None  # Loaded from preferences on first use
+_identified_git_hosts_lock = threading.Lock()
+
+
+def _load_identified_git_hosts() -> Dict[str, GitHost]:
+    """Read the identified hosts from the preferences. Must be called with the lock held."""
+
+    global _identified_git_hosts
+    if _identified_git_hosts is not None:
+        return _identified_git_hosts
+
+    _identified_git_hosts = {}
+    try:
+        stored = json.loads(fci.Preferences().get(IDENTIFIED_HOSTS_PREFERENCE))
+    except json.JSONDecodeError:
+        fci.Console.PrintWarning(
+            f"Could not read the {IDENTIFIED_HOSTS_PREFERENCE} preference: "
+            "the git hosts it names will be identified again\n"
+        )
+        stored = {}
+    if isinstance(stored, dict):
+        for netloc, host_name in stored.items():
+            if host_name in GIT_HOSTS_BY_NAME and netloc not in KNOWN_GIT_HOSTS:
+                _identified_git_hosts[netloc] = GIT_HOSTS_BY_NAME[host_name]
+    return _identified_git_hosts
+
+
+def _store_identified_git_hosts() -> None:
+    """Write the identified hosts back to the preferences. Must be called with the lock held."""
+
+    fci.Preferences().set(
+        IDENTIFIED_HOSTS_PREFERENCE,
+        json.dumps({netloc: host.name for netloc, host in _identified_git_hosts.items()}),
+    )
+
+
+def git_host_of(repo) -> Optional[GitHost]:
+    """The software running the git host of this repo, if it is known: either because it is one of
+    the hosts the Addon Manager ships, or because it was identified during this or an earlier run.
+    Returns None for a host that has not been identified."""
+
+    netloc = urlparse(repo.url).netloc
+    if netloc in KNOWN_GIT_HOSTS:
+        return KNOWN_GIT_HOSTS[netloc]
+    with _identified_git_hosts_lock:
+        return _load_identified_git_hosts().get(netloc)
+
+
+def remember_git_host(repo, host: GitHost) -> None:
+    """Record the software that a git host turned out to be running. This is stored in the user's
+    preferences, so that the host does not have to be identified again on the next run."""
+
+    netloc = urlparse(repo.url).netloc
+    if not netloc or netloc in KNOWN_GIT_HOSTS:
+        return
+    with _identified_git_hosts_lock:
+        identified = _load_identified_git_hosts()
+        if identified.get(netloc) == host:
+            return
+        fci.Console.PrintLog(f"Identified the git host at {netloc} as {host.name}\n")
+        identified[netloc] = host
+        _store_identified_git_hosts()
+
+
+def forget_git_host(repo) -> bool:
+    """Discard what was previously worked out about this repo's git host, so that it is identified
+    again. Returns True if there was anything to discard, which means it is worth another try."""
+
+    netloc = urlparse(repo.url).netloc
+    with _identified_git_hosts_lock:
+        identified = _load_identified_git_hosts()
+        if netloc not in identified:
+            return False
+        fci.Console.PrintLog(
+            f"The git host at {netloc} no longer answers as {identified[netloc].name}: "
+            "identifying it again\n"
+        )
+        del identified[netloc]
+        _store_identified_git_hosts()
+        return True
+
+
+def forget_git_hosts() -> None:
+    """Discard everything the Addon Manager has worked out about git hosts."""
+
+    with _identified_git_hosts_lock:
+        _load_identified_git_hosts().clear()
+        _store_identified_git_hosts()
+
+
+def reload_git_hosts() -> None:
+    """Discard the identified hosts held in memory and read them from the preferences again, as
+    happens the first time they are needed in a run of FreeCAD."""
+
+    global _identified_git_hosts
+    with _identified_git_hosts_lock:
+        _identified_git_hosts = None
+
+
+def _base_url(repo) -> str:
+    return repo.url[:-4] if repo.url.endswith(".git") else repo.url
+
+
+def _format_url(layout: str, repo, filename: str = "") -> str:
+    return layout.format(
+        url=_base_url(repo),
+        branch=repo.branch,
+        filename=filename,
+        name=getattr(repo, "name", ""),
+    )
+
+
+def identify_git_host(repo, serves_file) -> Optional[GitHost]:
+    """Work out which software an unrecognized git host is running, by asking it for the same file
+    in every layout the Addon Manager knows and deciding from the complete set of answers.
+
+    serves_file(url) must return True only if the host really served the file that was asked for.
+    Checking the status code is not enough to establish that: a git host that requires a login
+    answers every URL, including a nonsense one, with a 200 and a sign-in page.
+
+    Only Gitea and GitLab have a raw file layout that is exclusively theirs, so an answer at either
+    of those identifies the host outright. All three serve GitHub's layout, so an answer there only
+    means GitHub if neither of the exclusive layouts answered. A host that answers at both of the
+    exclusive layouts is contradicting itself and is left unidentified rather than guessed at."""
+
+    known = git_host_of(repo)
+    if known is not None:
+        return known  # Shipped, or identified on an earlier run: there is nothing to ask
+    if not urlparse(repo.url).netloc:
+        return None  # A local path, not a git host
+
+    answered = {
+        candidate
+        for candidate in CANDIDATE_GIT_HOSTS
+        if serves_file(_format_url(candidate.raw_file, repo, IDENTIFYING_FILE))
+    }
+    exclusive = {candidate for candidate in answered if candidate.raw_file_is_exclusive}
+
+    if len(exclusive) == 1:
+        return exclusive.pop()
+    if not exclusive and GITHUB in answered:
+        return GITHUB
+    return None
+
+
 def get_zip_url(repo):
     """Returns the location of a zip file from a repo, if available"""
 
-    parsed_url = urlparse(repo.url)
-    if parsed_url.netloc == "github.com":
-        return f"{repo.url}/archive/{repo.branch}.zip"
-    if parsed_url.netloc in ["gitlab.com", "framagit.org", "salsa.debian.org"]:
-        return f"{repo.url}/-/archive/{repo.branch}/{repo.name}-{repo.branch}.zip"
-    if parsed_url.netloc in ["codeberg.org"]:
-        return f"{repo.url}/archive/{repo.branch}.zip"
-    fci.Console.PrintLog(
-        "Debug: addonmanager_utilities.get_zip_url: Unknown git host fetching zip URL:"
-        + parsed_url.netloc
-        + "\n"
-    )
-    return f"{repo.url}/-/archive/{repo.branch}/{repo.name}-{repo.branch}.zip"
+    return _format_url(_host_or_default(repo).archive, repo)
 
 
 def recognized_git_location(repo) -> bool:
-    """Returns whether this repo is based at a known git repo location: works with GitHub, gitlab,
-    framagit, and salsa.debian.org"""
+    """Returns whether this repo is based at a git host that the Addon Manager ships support for"""
 
-    parsed_url = urlparse(repo.url)
-    return parsed_url.netloc in [
-        "github.com",
-        "gitlab.com",
-        "framagit.org",
-        "salsa.debian.org",
-        "codeberg.org",
-    ]
+    return urlparse(repo.url).netloc in KNOWN_GIT_HOSTS
 
 
 def construct_git_url(repo, filename):
     """Returns a direct download link to a file in an online Git repo"""
 
     parsed_url = urlparse(repo.url)
-    repo_url = repo.url[:-4] if repo.url.endswith(".git") else repo.url
-    if parsed_url.netloc == "github.com":
-        return f"{repo_url}/raw/{repo.branch}/{filename}"
-    if parsed_url.netloc in ["gitlab.com", "framagit.org", "salsa.debian.org"]:
-        return f"{repo_url}/-/raw/{repo.branch}/{filename}"
-    if parsed_url.netloc in ["codeberg.org"]:
-        return f"{repo_url}/raw/branch/{repo.branch}/{filename}"
-    if parsed_url.netloc == "":
-        return f"{parsed_url.path}/{filename}"
-    fci.Console.PrintLog(
-        "Debug: addonmanager_utilities.construct_git_url: Unknown git host:"
-        + parsed_url.netloc
-        + f" for file {filename}\n"
-    )
-    # Assume it's some kind of local GitLab instance...
-    return f"{repo_url}/-/raw/{repo.branch}/{filename}"
+    if not parsed_url.netloc:
+        return f"{parsed_url.path}/{filename}"  # A local path, not a remote host
+    return _format_url(_host_or_default(repo).raw_file, repo, filename)
 
 
 def get_readme_url(repo):
@@ -257,35 +439,24 @@ def get_readme_url(repo):
     return construct_git_url(repo, "README.md")
 
 
-def get_desc_regex(repo):
-    """Returns a regex string that extracts a WB description to be displayed in the description
-    panel of the Addon manager, if the README could not be found"""
-
-    parsed_url = urlparse(repo.url)
-    if parsed_url.netloc == "github.com":
-        return r'<meta property="og:description" content="(.*?)"'
-    if parsed_url.netloc in ["gitlab.com", "salsa.debian.org", "framagit.org"]:
-        return r'<meta.*?content="(.*?)".*?og:description.*?>'
-    if parsed_url.netloc in ["codeberg.org"]:
-        return r'<meta property="og:description" content="(.*?)"'
-    fci.Console.PrintLog(
-        f"Debug: addonmanager_utilities.get_desc_regex: Unknown git host: {repo.url}\n"
-    )
-    return r'<meta.*?content="(.*?)".*?og:description.*?>'
-
-
 def get_readme_html_url(repo):
     """Returns the location of a html file containing readme"""
 
-    parsed_url = urlparse(repo.url)
-    if parsed_url.netloc == "github.com":
-        return f"{repo.url}/blob/{repo.branch}/README.md"
-    if parsed_url.netloc in ["gitlab.com", "salsa.debian.org", "framagit.org"]:
-        return f"{repo.url}/-/blob/{repo.branch}/README.md"
-    if parsed_url.netloc in ["gitlab.com", "salsa.debian.org", "framagit.org"]:
-        return f"{repo.url}/raw/branch/{repo.branch}/README.md"
-    fci.Console.PrintLog("Unrecognized git repo location '' -- guessing it is a GitLab instance...")
-    return f"{repo.url}/-/blob/{repo.branch}/README.md"
+    return _format_url(_host_or_default(repo).blob, repo, "README.md")
+
+
+def _host_or_default(repo) -> GitHost:
+    """The layout to use for this repo's git host, falling back to the default for a host that has
+    not been identified."""
+
+    host = git_host_of(repo)
+    if host is not None:
+        return host
+    fci.Console.PrintLog(
+        f"Debug: the git host at {urlparse(repo.url).netloc} has not been identified: "
+        f"assuming it is running {DEFAULT_GIT_HOST.name}\n"
+    )
+    return DEFAULT_GIT_HOST
 
 
 def is_darkmode() -> bool:

--- a/addonmanager_workers_startup.py
+++ b/addonmanager_workers_startup.py
@@ -136,7 +136,13 @@ class CreateAddonListWorker(QtCore.QThread):
         entry = AddonCatalogEntry(
             {"repository": url, "git_ref": branch, "branch_display_name": branch}
         )
-        entry.metadata = self._fetch_custom_addon_metadata(name, url, branch)
+        location = SimpleNamespace(url=url, branch=branch, name=name)
+
+        entry.metadata = self._fetch_custom_addon_metadata(name, location)
+        if entry.metadata is None and utils.forget_git_host(location):
+            # The host we had identified answered nothing at all. It may be running different
+            # software than it was when it was identified, so work out what it is now and retry.
+            entry.metadata = self._fetch_custom_addon_metadata(name, location)
         if entry.metadata is None:
             # Something is wrong: fall back to using the installed metadata
             entry.metadata = self._load_installed_addon_metadata(name)
@@ -158,16 +164,42 @@ class CreateAddonListWorker(QtCore.QThread):
 
         return addon
 
-    def _fetch_custom_addon_metadata(
-        self, name: str, url: str, branch: str
-    ) -> Optional[CatalogEntryMetadata]:
+    def _fetch_custom_addon_metadata(self, name: str, location) -> Optional[CatalogEntryMetadata]:
         """Fetch the metadata files of a custom repository directly from its git host."""
 
-        location = SimpleNamespace(url=url, branch=branch)
+        self._identify_git_host(location)
         return self._collect_addon_metadata(
             name,
             lambda filename: self._fetch_remote_file(utils.construct_git_url(location, filename)),
         )
+
+    def _identify_git_host(self, location) -> None:
+        """Work out which software this repository's git host is running, unless that is already
+        known. The answer is stored in the user's preferences, so this happens only once for any
+        given host, which is why it can afford to ask the host several questions."""
+
+        host = utils.identify_git_host(location, self._serves_package_xml)
+        if host is None:
+            fci.Console.PrintLog(
+                f"Could not work out what software the git host at {location.url} is running. "
+                f"Add a package.xml file to the repository to let the Addon Manager identify it.\n"
+            )
+            return
+        utils.remember_git_host(location, host)
+
+    def _serves_package_xml(self, url: str) -> bool:
+        """Whether the repository really served a package.xml at this URL. The contents have to be
+        checked: a git host that requires a login answers every URL with a 200 and a sign-in page,
+        and that must not be mistaken for the file."""
+
+        data = self._fetch_remote_file(url)
+        if not data:
+            return False
+        try:
+            MetadataReader.from_bytes(data)
+        except (XmlParseError, RuntimeError):
+            return False
+        return True
 
     def _load_installed_addon_metadata(self, name: str) -> Optional[CatalogEntryMetadata]:
         """Load the metadata files of a custom repository from its installed copy, if there is
@@ -206,17 +238,41 @@ class CreateAddonListWorker(QtCore.QThread):
                 if icon_data:
                     metadata.icon_data = base64.b64encode(icon_data).decode("utf-8")
 
-        requirements_txt = get_file("requirements.txt")
+        requirements_txt = cls._text_file(name, "requirements.txt", get_file)
         if requirements_txt:
-            metadata.requirements_txt = cls._decode(requirements_txt)
+            metadata.requirements_txt = requirements_txt
 
-        metadata_txt = get_file("metadata.txt")
+        metadata_txt = cls._text_file(name, "metadata.txt", get_file)
         if metadata_txt:
-            metadata.metadata_txt = cls._decode(metadata_txt)
+            metadata.metadata_txt = metadata_txt
 
         if metadata.package_xml or metadata.requirements_txt or metadata.metadata_txt:
             return metadata
         return None
+
+    @classmethod
+    def _text_file(cls, name: str, filename: str, get_file) -> Optional[str]:
+        """Retrieve one of the plain text metadata files, unless what came back is a web page. A
+        git host that requires a login answers every request with a 200 and a sign-in page: without
+        this check its HTML would be read as though it were a list of the addon's dependencies."""
+
+        data = get_file(filename)
+        if not data:
+            return None
+        if cls._is_html(data):
+            fci.Console.PrintLog(
+                f"The {filename} of custom addon {name} came back as a web page, not a file. "
+                f"Ignoring it: the repository may be private, or may not exist.\n"
+            )
+            return None
+        return cls._decode(data)
+
+    @staticmethod
+    def _is_html(data: bytes) -> bool:
+        """Whether these are the contents of a web page rather than of an addon's metadata file."""
+
+        beginning = data.lstrip()[:64].lower()
+        return beginning.startswith(b"<!doctype html") or beginning.startswith(b"<html")
 
     @staticmethod
     def _decode(data: bytes) -> str:


### PR DESCRIPTION
Part of the process of fixing custom repos: instead of only allowing a set of known hosts, and otherwise assuming the URL layout is the one used by Gitlab, actually attempt to fetch from the guessed URL formats and check the results against host formats we know about. This should do a better job of supporting unknown (often privately-hosted) git hosts.