### PR TITLE
Unify strings

### DIFF
--- a/AddonManagerOptions.ui
+++ b/AddonManagerOptions.ui
@@ -136,10 +136,10 @@
    <item>
     <widget class="QGroupBox" name="proxyGroupBox">
      <property name="toolTip">
-      <string>Use a proxy server for access to addon data</string>
+      <string>Uses a proxy server to access addon data</string>
      </property>
      <property name="title">
-      <string>Proxy addon manager traffic</string>
+      <string>Proxy Addon Manager traffic</string>
      </property>
      <property name="flat">
       <bool>false</bool>
@@ -156,7 +156,7 @@
         <item>
          <widget class="QRadioButton" name="systemProxyButton">
           <property name="toolTip">
-           <string>Use the system's proxy settings</string>
+           <string>Uses the system proxy settings</string>
           </property>
           <property name="text">
            <string>System</string>
@@ -172,7 +172,7 @@
         <item>
          <widget class="QRadioButton" name="customProxyButton">
           <property name="toolTip">
-           <string>Use custom proxy settings</string>
+           <string>Uses custom proxy settings</string>
           </property>
           <property name="text">
            <string>Custom</string>
@@ -229,7 +229,7 @@
         <item row="1" column="4">
          <widget class="QPushButton" name="proxyTestButton">
           <property name="toolTip">
-           <string>Test these proxy settings</string>
+           <string>Tests these proxy settings</string>
           </property>
           <property name="text">
            <string>Test Connection</string>
@@ -278,7 +278,7 @@
         </sizepolicy>
        </property>
        <property name="toolTip">
-        <string>The URL for the addon score data (see Addon Manager wiki page for formatting and hosting details)</string>
+        <string>Specifies the URL for addon score data</string>
        </property>
        <property name="prefEntry" stdset="0">
         <cstring>AddonsScoreURL</cstring>

--- a/Widgets/addonmanager_widget_addon_buttons.py
+++ b/Widgets/addonmanager_widget_addon_buttons.py
@@ -169,8 +169,8 @@ class WidgetAddonButtons(QtWidgets.QWidget):
         self.enable.setText(translate("AddonsInstaller", "Enable"))
         self.update.setText(translate("AddonsInstaller", "Update"))
         self.run_macro.setText(translate("AddonsInstaller", "Run"))
-        self.back.setToolTip(translate("AddonsInstaller", "Return to Package List"))
-        self.spinner.setToolTip(translate("AddonsInstaller", "Checking for Updates…"))
+        self.back.setToolTip(translate("AddonsInstaller", "Returns to the package list"))
+        self.spinner.setToolTip(translate("AddonsInstaller", "Checking for updates…"))
         if self.is_addon_manager:
             self.uninstall.setText(translate("AddonsInstaller", "Revert to Built-In"))
         else:

--- a/Widgets/addonmanager_widget_view_selector.py
+++ b/Widgets/addonmanager_widget_view_selector.py
@@ -137,6 +137,6 @@ class WidgetViewSelector(QtWidgets.QWidget):
         )
 
     def retranslateUi(self, _):
-        self.composite_button.setToolTip(translate("AddonsInstaller", "Composite view"))
-        self.expanded_button.setToolTip(translate("AddonsInstaller", "Expanded view"))
-        self.compact_button.setToolTip(translate("AddonsInstaller", "Compact view"))
+        self.composite_button.setToolTip(translate("AddonsInstaller", "Shows the composite view"))
+        self.expanded_button.setToolTip(translate("AddonsInstaller", "Shows the expanded view"))
+        self.compact_button.setToolTip(translate("AddonsInstaller", "Shows the compact view"))

--- a/addonmanager_connection_checker.py
+++ b/addonmanager_connection_checker.py
@@ -63,8 +63,8 @@ class ConnectionCheckerGUI(QtCore.QObject):
         if not self.connection_checker.isFinished():
             self.connection_check_message = QtWidgets.QMessageBox(
                 QtWidgets.QMessageBox.Information,
-                translate("AddonsInstaller", "Checking connection"),
-                translate("AddonsInstaller", "Checking for connection to addons.freecad.org..."),
+                translate("AddonsInstaller", "Checking Connection"),
+                translate("AddonsInstaller", "Checking the connection to addons.freecad.org…"),
                 QtWidgets.QMessageBox.Cancel,
             )
             self.connection_check_message.setObjectName("AddonManager_ConnectionCheckMessageDialog")
@@ -90,7 +90,7 @@ class ConnectionCheckerGUI(QtCore.QObject):
         MessageDialog.show_modal(
             MessageDialog.DialogType.ERROR,
             "AddonManager_ConnectionFailedDialog",
-            translate("AddonsInstaller", "Connection failed"),
+            translate("AddonsInstaller", "Connection Failed"),
             message,
             QtWidgets.QMessageBox.Ok,
         )

--- a/addonmanager_installer_gui.py
+++ b/addonmanager_installer_gui.py
@@ -644,7 +644,7 @@ class AddonDependencyInstallerGUI(QtCore.QObject):
             MessageDialog.show_modal(
                 MessageDialog.DialogType.ERROR,
                 "AddonManager_IncompatiblePythonVersionDialog",
-                translate("AddonsInstaller", "Incompatible Python version"),
+                translate("AddonsInstaller", "Incompatible Python Version"),
                 translate(
                     "AddonsInstaller",
                     "This addon (or one of its dependencies) requires Python {}, and your system"
@@ -721,7 +721,7 @@ class AddonDependencyInstallerGUI(QtCore.QObject):
         result = MessageDialog.show_modal(
             MessageDialog.DialogType.ERROR,
             "AddonManager_CannotExecutePythonDialog",
-            translate("AddonsInstaller", "Cannot execute Python"),
+            translate("AddonsInstaller", "Cannot Execute Python"),
             translate(
                 "AddonsInstaller",
                 "Failed to automatically locate your Python executable, or the path is set "
@@ -747,7 +747,7 @@ class AddonDependencyInstallerGUI(QtCore.QObject):
         result = MessageDialog.show_modal(
             MessageDialog.DialogType.ERROR,
             "AddonManager_CannotExecutePipDialog",
-            translate("AddonsInstaller", "Cannot execute pip"),
+            translate("AddonsInstaller", "Cannot Execute pip"),
             translate(
                 "AddonsInstaller",
                 "Failed to execute pip, which may be missing from your Python installation. Please "
@@ -775,7 +775,7 @@ class AddonDependencyInstallerGUI(QtCore.QObject):
         result = MessageDialog.show_modal(
             MessageDialog.DialogType.ERROR,
             "AddonManager_PackageInstallationFailedDialog",
-            translate("AddonsInstaller", "Package installation failed"),
+            translate("AddonsInstaller", "Package Installation Failed"),
             short_message
             + "\n\n"
             + translate("AddonsInstaller", "See Report View for detailed failure log.")

--- a/addonmanager_python_deps.py
+++ b/addonmanager_python_deps.py
@@ -298,11 +298,11 @@ class PythonPackageListModel(QtCore.QAbstractTableModel):
             if section == 0:
                 return translate("AddonsInstaller", "Package")
             elif section == 1:
-                return translate("AddonsInstaller", "Installed Version")
+                return translate("AddonsInstaller", "Installed version")
             elif section == 2:
-                return translate("AddonsInstaller", "Available Version")
+                return translate("AddonsInstaller", "Available version")
             elif section == 3:
-                return translate("AddonsInstaller", "Used By")
+                return translate("AddonsInstaller", "Used by")
         return None
 
     def flags(self, index) -> QtCore.Qt.ItemFlag:

--- a/addonmanager_readme_controller.py
+++ b/addonmanager_readme_controller.py
@@ -207,7 +207,7 @@ class ReadmeController(QtCore.QObject):
         self.widget.setUrl(self.url)
 
         self.widget.setText(
-            translate("AddonsInstaller", "Loading page for {} from {}...").format(
+            translate("AddonsInstaller", "Loading page for {} from {}…").format(
                 self.addon.display_name, self.url
             )
         )

--- a/addonmanager_uninstaller_gui.py
+++ b/addonmanager_uninstaller_gui.py
@@ -83,7 +83,7 @@ class AddonUninstallerGUI(QtCore.QObject):
         confirm = MessageDialog.show_modal(
             MessageDialog.DialogType.QUESTION,
             "AddonManager_ConfirmUninstallDialog",
-            translate("AddonsInstaller", "Confirm remove"),
+            translate("AddonsInstaller", "Confirm Remove"),
             translate("AddonsInstaller", "Are you sure you want to uninstall {}?").format(
                 self.addon_to_remove.display_name
             ),
@@ -96,7 +96,7 @@ class AddonUninstallerGUI(QtCore.QObject):
             QtWidgets.QMessageBox.NoIcon,
             translate("AddonsInstaller", "Removing Addon"),
             translate("AddonsInstaller", "Removing {}").format(self.addon_to_remove.display_name)
-            + "...",
+            + "…",
             QtWidgets.QMessageBox.Cancel,
             parent=utils.get_main_am_window(),
         )
@@ -120,7 +120,7 @@ class AddonUninstallerGUI(QtCore.QObject):
         MessageDialog.show_modal(
             MessageDialog.DialogType.INFO,
             "AddonManager_UninstallCompleteDialog",
-            translate("AddonsInstaller", "Uninstall complete"),
+            translate("AddonsInstaller", "Uninstall Complete"),
             translate("AddonInstaller", "Finished removing {}").format(addon.display_name),
             QtWidgets.QMessageBox.Ok,
         )
@@ -134,7 +134,7 @@ class AddonUninstallerGUI(QtCore.QObject):
         MessageDialog.show_modal(
             MessageDialog.DialogType.ERROR,
             "AddonManager_UninstallFailedDialog",
-            translate("AddonsInstaller", "Uninstall failed"),
+            translate("AddonsInstaller", "Uninstall Failed"),
             translate("AddonInstaller", "Failed to remove some files") + ":\n" + message,
             QtWidgets.QMessageBox.Ok,
         )

--- a/addonmanager_update_all_gui.py
+++ b/addonmanager_update_all_gui.py
@@ -407,8 +407,8 @@ class UpdatesAvailableModel(QtCore.QAbstractTableModel):
         self.update_is_done: List[bool] = []
         self.headers = [
             translate("AddonsInstaller", "Name", "Column header"),
-            translate("AddonsInstaller", "Installed Version", "Column header"),
-            translate("AddonsInstaller", "Available Version", "Column header"),
+            translate("AddonsInstaller", "Installed version", "Column header"),
+            translate("AddonsInstaller", "Available version", "Column header"),
             translate("AddonsInstaller", "Update?", "Column header"),
             translate("AddonsInstaller", "Done", "Column header"),
         ]

--- a/compact_view.py
+++ b/compact_view.py
@@ -89,7 +89,7 @@ class Ui_CompactView(object):
         #        CompactView.setWindowTitle(QCoreApplication.translate("CompactView", "Form", None))
         self.labelIcon.setText(QtCore.QCoreApplication.translate("CompactView", "Icon", None))
         self.labelPackageName.setText(
-            QtCore.QCoreApplication.translate("CompactView", "<b>Package Name</b>", None)
+            QtCore.QCoreApplication.translate("CompactView", "<b>Package name</b>", None)
         )
         self.labelVersion.setText(QtCore.QCoreApplication.translate("CompactView", "Version", None))
         self.labelDescription.setText(

--- a/dependency_resolution_dialog.ui
+++ b/dependency_resolution_dialog.ui
@@ -26,9 +26,9 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>This installation/update has the following required and optional dependencies.
+      <string>The following dependencies are required or optional for this installation or update.
 
-Do you want the Addon Manager to install them automatically? Choose "Ignore" to install/update without installing the dependencies.</string>
+Choose "Ignore" to continue without installing dependencies.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/expanded_view.py
+++ b/expanded_view.py
@@ -138,7 +138,7 @@ class Ui_ExpandedView(object):
         #        ExpandedView.setWindowTitle(QCoreApplication.translate("ExpandedView", "Form", None))
         self.labelIcon.setText(QtCore.QCoreApplication.translate("ExpandedView", "Icon", None))
         self.labelPackageName.setText(
-            QtCore.QCoreApplication.translate("ExpandedView", "<h1>Package Name</h1>", None)
+            QtCore.QCoreApplication.translate("ExpandedView", "<h1>Package name</h1>", None)
         )
         self.labelVersion.setText(
             QtCore.QCoreApplication.translate("ExpandedView", "Version", None)

--- a/select_toolbar_dialog.ui
+++ b/select_toolbar_dialog.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Select a toolbar to add this macro to</string>
+      <string>Adds this macro to the selected toolbar</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
I've launched a fresh FreeCAD weekly and was greeted an abnormality:
<img width="266" height="114" alt="Bildschirmfoto 2026-07-18 um 19 45 59" src="https://github.com/user-attachments/assets/0e7f3f40-7fcb-4117-846e-41ef89714722" />

The Python package manager was not in Title Case!
When installing the Addon Manager it was fixed (https://github.com/FreeCAD/AddonManager/pull/421) but I found some other strings.
