### PR TITLE
Revert defused xml configure check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # SPDX-FileNotice: Part of the AddonManager.
 
-# The Addon Manager requires the defusedxml package at runtime to safely parse addon metadata. Unlike
-# the optional Python packages that individual addons depend on, defusedxml is a hard dependency of the
-# Addon Manager itself, so verify that it is importable at configure time rather than deferring the
-# failure to the user's first launch.
-IF (Python3_EXECUTABLE)
-    execute_process(
-        COMMAND "${Python3_EXECUTABLE}" "-c" "import defusedxml"
-        RESULT_VARIABLE ADDONMANAGER_DEFUSEDXML_MISSING
-        OUTPUT_QUIET
-        ERROR_QUIET
-    )
-    IF (ADDONMANAGER_DEFUSEDXML_MISSING)
-        MESSAGE(FATAL_ERROR
-            "The Addon Manager requires the Python package 'defusedxml', which was not found for "
-            "${Python3_EXECUTABLE}. Install it (for example, 'pip install defusedxml') and reconfigure.")
-    ELSE ()
-        MESSAGE(STATUS "Found required Addon Manager dependency: defusedxml")
-    ENDIF ()
-ELSE ()
-    MESSAGE(WARNING
-        "Python3_EXECUTABLE is not set, so the Addon Manager cannot verify that its required "
-        "'defusedxml' dependency is installed.")
-ENDIF ()
-
 IF (BUILD_GUI)
     add_subdirectory(Widgets)
 ENDIF (BUILD_GUI)

--- a/package.xml
+++ b/package.xml
@@ -5,8 +5,8 @@
     <name>Addon Manager</name>
     <description>Development branch of a tool to install workbenches, macros, themes, etc.</description>
     <icon>Resources/icons/addon_manager.svg</icon>
-    <version>2026.8.16dev</version>
-    <date>2026-08-16</date>
+    <version>2026.8.18dev</version>
+    <date>2026-08-18</date>
     <maintainer email='chennes@freecad.org'>Chris Hennes</maintainer>
     <author email = 'yorik@uncreated.net'>Yorik van Havre</author>
     <author>Jonathan Wiedemann</author>


### PR DESCRIPTION
Revert the addition of the configure-time defusedxml check -- our packaging properly declares this as a runtime dependency, and does not install it at build time. That's as it should be, so it should work.